### PR TITLE
fix(request-builder): Fix for semicolon in building form param

### DIFF
--- a/core/request_builder.go
+++ b/core/request_builder.go
@@ -156,9 +156,9 @@ func (requestBuilder *RequestBuilder) createMultipartWriter() *multipart.Writer 
 // a new form-data header with the provided field name and file name and contentType
 func createFormFile(formWriter *multipart.Writer, fieldname string, filename string, contentType string) (io.Writer, error) {
 	h := make(textproto.MIMEHeader)
-	contentDisposition := fmt.Sprintf(`form-data; name="%s";`, fieldname)
+	contentDisposition := fmt.Sprintf(`form-data; name="%s"`, fieldname)
 	if filename != "" {
-		contentDisposition += fmt.Sprintf(` filename="%s"`, filename)
+		contentDisposition += fmt.Sprintf(`; filename="%s"`, filename)
 	}
 
 	h.Set(CONTENT_DISPOSITION, contentDisposition)


### PR DESCRIPTION
The new feature for document translator in LTV3 gave a `request canceled (Client.Timeout exceeded while awaiting headers` as the server didnt like a request containing an extra semicolon in the request:
`Content-Disposition: form-data; name="model_id";`