### PR TITLE
feat: support correct service key transformations when loading external config properties

### DIFF
--- a/core/authenticator_factory_test.go
+++ b/core/authenticator_factory_test.go
@@ -33,7 +33,7 @@ func TestGetAuthenticatorFromEnvironment1(t *testing.T) {
 	credentialFilePath := path.Join(pwd, "/../resources/my-credentials.env")
 	os.Setenv("IBM_CREDENTIALS_FILE", credentialFilePath)
 
-	authenticator, err := GetAuthenticatorFromEnvironment("service1")
+	authenticator, err := GetAuthenticatorFromEnvironment("service-1")
 	assert.Nil(t, err)
 	assert.NotNil(t, authenticator)
 	assert.Equal(t, AUTHTYPE_IAM, authenticator.AuthenticationType())
@@ -54,7 +54,7 @@ func TestGetAuthenticatorFromEnvironment1(t *testing.T) {
 func TestGetAuthenticatorFromEnvironment2(t *testing.T) {
 	setTestEnvironment()
 
-	authenticator, err := GetAuthenticatorFromEnvironment("service1")
+	authenticator, err := GetAuthenticatorFromEnvironment("service-1")
 	assert.Nil(t, err)
 	assert.NotNil(t, authenticator)
 	assert.Equal(t, AUTHTYPE_IAM, authenticator.AuthenticationType())
@@ -79,7 +79,7 @@ func TestGetAuthenticatorFromEnvironment2(t *testing.T) {
 func TestGetAuthenticatorFromEnvironment3(t *testing.T) {
 	setTestVCAP()
 
-	authenticator, err := GetAuthenticatorFromEnvironment("service1")
+	authenticator, err := GetAuthenticatorFromEnvironment("service-1")
 	assert.Nil(t, err)
 	assert.NotNil(t, authenticator)
 	assert.Equal(t, AUTHTYPE_IAM, authenticator.AuthenticationType())

--- a/core/base_service_test.go
+++ b/core/base_service_test.go
@@ -600,7 +600,7 @@ func TestExtConfigFromCredentialFile(t *testing.T) {
 		&ServiceOptions{
 			Authenticator: &NoAuthAuthenticator{},
 			URL:           "bad url",
-		}, "service1", "service1")
+		}, "service-1", "service-1")
 	assert.Nil(t, err)
 	assert.NotNil(t, service)
 	assert.Equal(t, "https://service1/api", service.Options.URL)

--- a/core/config_utils.go
+++ b/core/config_utils.go
@@ -171,6 +171,8 @@ func parsePropertyStrings(credentialKey string, propertyStrings []string) map[st
 
 	props := make(map[string]string)
 	credentialKey = strings.ToUpper(credentialKey)
+	credentialKey = strings.Replace(credentialKey, "-", "_", -1)
+	credentialKey += "_"
 	for _, propertyString := range propertyStrings {
 
 		// Trim the property string and ignore any blank or comment lines.
@@ -185,8 +187,8 @@ func parsePropertyStrings(credentialKey string, propertyStrings []string) map[st
 			// Does the name start with the credential key?
 			// If so, then extract the property name by filtering out the credential key,
 			// then store the name/value pair in the map.
-			if strings.HasPrefix(tokens[0], credentialKey) && (len(tokens[0]) > len(credentialKey)+1) {
-				name := tokens[0][len(credentialKey)+1:]
+			if strings.HasPrefix(tokens[0], credentialKey) && (len(tokens[0]) > len(credentialKey)) {
+				name := tokens[0][len(credentialKey):]
 				value := strings.TrimSpace(tokens[1])
 				props[name] = value
 			}

--- a/core/config_utils_test.go
+++ b/core/config_utils_test.go
@@ -25,26 +25,26 @@ import (
 
 // Map containing environment variables used in testing.
 var testEnvironment = map[string]string{
-	"SERVICE1_URL":              "https://service1/api",
-	"SERVICE1_DISABLE_SSL":      "true",
-	"SERVICE1_AUTH_TYPE":        "IaM",
-	"SERVICE1_APIKEY":           "my-api-key",
-	"SERVICE1_CLIENT_ID":        "my-client-id",
-	"SERVICE1_CLIENT_SECRET":    "my-client-secret",
-	"SERVICE1_AUTH_URL":         "https://iamhost/iam/api",
-	"SERVICE1_AUTH_DISABLE_SSL": "true",
-	"SERVICE2_URL":              "https://service2/api",
-	"SERVICE2_DISABLE_SSL":      "false",
-	"SERVICE2_AUTH_TYPE":        "bAsIC",
-	"SERVICE2_USERNAME":         "my-user",
-	"SERVICE2_PASSWORD":         "my-password",
-	"SERVICE3_URL":              "https://service3/api",
-	"SERVICE3_DISABLE_SSL":      "false",
-	"SERVICE3_AUTH_TYPE":        "Cp4D",
-	"SERVICE3_AUTH_URL":         "https://cp4dhost/cp4d/api",
-	"SERVICE3_USERNAME":         "my-cp4d-user",
-	"SERVICE3_PASSWORD":         "my-cp4d-password",
-	"SERVICE3_AUTH_DISABLE_SSL": "false",
+	"SERVICE_1_URL":              "https://service1/api",
+	"SERVICE_1_DISABLE_SSL":      "true",
+	"SERVICE_1_AUTH_TYPE":        "IaM",
+	"SERVICE_1_APIKEY":           "my-api-key",
+	"SERVICE_1_CLIENT_ID":        "my-client-id",
+	"SERVICE_1_CLIENT_SECRET":    "my-client-secret",
+	"SERVICE_1_AUTH_URL":         "https://iamhost/iam/api",
+	"SERVICE_1_AUTH_DISABLE_SSL": "true",
+	"SERVICE2_URL":               "https://service2/api",
+	"SERVICE2_DISABLE_SSL":       "false",
+	"SERVICE2_AUTH_TYPE":         "bAsIC",
+	"SERVICE2_USERNAME":          "my-user",
+	"SERVICE2_PASSWORD":          "my-password",
+	"SERVICE3_URL":               "https://service3/api",
+	"SERVICE3_DISABLE_SSL":       "false",
+	"SERVICE3_AUTH_TYPE":         "Cp4D",
+	"SERVICE3_AUTH_URL":          "https://cp4dhost/cp4d/api",
+	"SERVICE3_USERNAME":          "my-cp4d-user",
+	"SERVICE3_PASSWORD":          "my-cp4d-password",
+	"SERVICE3_AUTH_DISABLE_SSL":  "false",
 }
 
 // Set the environment variables described in our map.
@@ -65,7 +65,7 @@ func clearTestEnvironment() {
 func setTestVCAP() {
 	vcapServices := `
 	{
-		"service1":[{
+		"service-1":[{
 			"credentials":{
 				"url":"https://service1/api",
 				"username":"my-vcap-user",
@@ -111,7 +111,7 @@ func TestGetServicePropertiesFromCredentialFile(t *testing.T) {
 	credentialFilePath := path.Join(pwd, "/../resources/my-credentials.env")
 	os.Setenv("IBM_CREDENTIALS_FILE", credentialFilePath)
 
-	props, err := getServiceProperties("service1")
+	props, err := getServiceProperties("service-1")
 	assert.Nil(t, err)
 	assert.NotNil(t, props)
 	assert.Equal(t, "https://service1/api", props[PROPNAME_SVC_URL])
@@ -153,7 +153,7 @@ func TestGetServicePropertiesFromCredentialFile(t *testing.T) {
 func TestGetServicePropertiesFromEnvironment(t *testing.T) {
 	setTestEnvironment()
 
-	props, err := getServiceProperties("service1")
+	props, err := getServiceProperties("service-1")
 	assert.Nil(t, err)
 	assert.NotNil(t, props)
 	assert.Equal(t, "https://service1/api", props[PROPNAME_SVC_URL])
@@ -190,13 +190,13 @@ func TestGetServicePropertiesFromEnvironment(t *testing.T) {
 	assert.Nil(t, props)
 
 	clearTestEnvironment()
-	assert.Equal(t, "", os.Getenv("SERVICE1_URL"))
+	assert.Equal(t, "", os.Getenv("SERVICE_1_URL"))
 }
 
 func TestGetServicePropertiesFromVCAP(t *testing.T) {
 	setTestVCAP()
 
-	props, err := getServiceProperties("service1")
+	props, err := getServiceProperties("service-1")
 	assert.Nil(t, err)
 	assert.NotNil(t, props)
 	assert.Equal(t, "https://service1/api", props[PROPNAME_SVC_URL])

--- a/resources/my-credentials.env
+++ b/resources/my-credentials.env
@@ -1,6 +1,6 @@
 # Service-specific properties not related to authentication.
-SERVICE1_URL=https://service1/api
-SERVICE1_DISABLE_SSL=true
+SERVICE_1_URL=https://service1/api
+SERVICE_1_DISABLE_SSL=true
 
 SERVICE2_URL=https://service2/api
 SERVICE2_DISABLE_SSL=false
@@ -15,12 +15,12 @@ SERVICE5_URL=https://service5/api
 SERVICE5_DISABLE_SSL=true
 
 # Service1 configured with IAM
-SERVICE1_AUTH_TYPE=IAM
-SERVICE1_APIKEY=my-api-key
-SERVICE1_CLIENT_ID=my-client-id
-SERVICE1_CLIENT_SECRET=my-client-secret
-SERVICE1_AUTH_URL=https://iamhost/iam/api
-SERVICE1_AUTH_DISABLE_SSL=true
+SERVICE_1_AUTH_TYPE=IAM
+SERVICE_1_APIKEY=my-api-key
+SERVICE_1_CLIENT_ID=my-client-id
+SERVICE_1_CLIENT_SECRET=my-client-secret
+SERVICE_1_AUTH_URL=https://iamhost/iam/api
+SERVICE_1_AUTH_DISABLE_SSL=true
 
 # Service2 configured with Basic Auth
 SERVICE2_AUTH_TYPE=BasiC


### PR DESCRIPTION
This PR includes a small change to config_utils.go that adds the required transformation of the credential key (service name) when using it to form the names of external config properties in credential files or environment variables.
The transformation is essentially to replace - with _ and to fold the credential key to upper case, then use it to form a cred file property or environment variable name.