### PR TITLE
feat: return more information in the DetailedResponse

### DIFF
--- a/core/detailed_response.go
+++ b/core/detailed_response.go
@@ -20,11 +20,40 @@ import (
 	"net/http"
 )
 
-// DetailedResponse : Generic response for IBM API
+// DetailedResponse : Each generated service method will return an instance of this struct.
 type DetailedResponse struct {
-	StatusCode int         // HTTP status code
-	Headers    http.Header // HTTP response headers
-	Result     interface{} // response from service
+
+	// The HTTP status code associated with the response.
+	StatusCode int
+
+	// The HTTP headers contained in the response.
+	Headers http.Header
+
+	// Result - this field will contain the result of the operation (obtained from the response body).
+	//
+	// If the operation was successful and the response body contains a JSON response, it is unmarshalled
+	// into an object of the appropriate type (defined by the particular operation), and the Result field will contain
+	// this response object. To retrieve this response object in its properly-typed form, use the
+	// generated service's "Get<operation-name>Result()" method.
+	// If there was an error while unmarshalling the JSON response body, then the RawResult field
+	// will be set to the byte array containing the response body.
+	//
+	// If the operation was successful and the response body contains a non-JSON response,
+	// the Result field will be an instance of io.ReadCloser that can be used by the application to read
+	// the response data.
+	//
+	// If the operation was unsuccessful and the response body contains a JSON response,
+	// this field will contain an instance of map[string]interface{} which is the result of unmarshalling the
+	// response body as a "generic" JSON object.
+	// If the JSON response for an unsuccessful operation could not be properly unmarshalled, then the
+	// RawResult field will contain the raw response body.
+	Result interface{}
+
+	// This field will contain the raw response body as a byte array under these conditions:
+	// 1) there was a problem unmarshalling a JSON response body -
+	// either for a successful or unsuccessful operation.
+	// 2) the operation was unsuccessful, and the response body contains a non-JSON response.
+	RawResult []byte
 }
 
 // GetHeaders returns the headers
@@ -40,6 +69,18 @@ func (response *DetailedResponse) GetStatusCode() int {
 // GetResult returns the result from the service
 func (response *DetailedResponse) GetResult() interface{} {
 	return response.Result
+}
+
+// GetResultAsMap returns the result as a map (generic JSON object), if the
+// DetailedResponse.Result field contains an instance of a map.
+func (response *DetailedResponse) GetResultAsMap() (map[string]interface{}, bool) {
+	m, ok := response.Result.(map[string]interface{})
+	return m, ok
+}
+
+// GetRawResult returns the raw response body as a byte array.
+func (response *DetailedResponse) GetRawResult() []byte {
+	return response.RawResult
 }
 
 func (response *DetailedResponse) String() string {


### PR DESCRIPTION
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/999

This PR enhances the Go core's ability to return as much information as possible from the operation response in the DetailedResponse structure.
Highlights of changes:
1. In the case of a successful invocation:
    * if the response body is not JSON, we'll return it as a byte array in the new `DetailedResponse.RawResult` field.
2. In the case of an unsuccessful invocation:
    * (as before) we'll obtain an error message from the response body and return it in an error object.
    * (new) we'll decode the entire response body (presumably containing an error structure) as a map and return it in the `DetailedResponse.Result` field.
3. Added new DetailedResponse methods to retrieve the RawResult and Result (as map) values.