### PR TITLE
Defer service URL validation

### DIFF
--- a/core/base_service_test.go
+++ b/core/base_service_test.go
@@ -41,9 +41,10 @@ func TestGoodResponseJSON(t *testing.T) {
 	}))
 	defer server.Close()
 
-	builder := NewRequestBuilder("POST").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddHeader("Content-Type", "Application/json").
+	builder := NewRequestBuilder("POST")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddHeader("Content-Type", "Application/json").
 		AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
@@ -81,9 +82,10 @@ func TestGoodResponseJSONExtraFields(t *testing.T) {
 	}))
 	defer server.Close()
 
-	builder := NewRequestBuilder("GET").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddHeader("Content-Type", "Application/json").
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddHeader("Content-Type", "Application/json").
 		AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
@@ -108,9 +110,10 @@ func TestGoodResponseNonJSON(t *testing.T) {
 	}))
 	defer server.Close()
 
-	builder := NewRequestBuilder("GET").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddHeader("Content-Type", "Application/json").
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddHeader("Content-Type", "Application/json").
 		AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
@@ -149,9 +152,10 @@ func TestGoodResponseNonJSONNoContentType(t *testing.T) {
 	}))
 	defer server.Close()
 
-	builder := NewRequestBuilder("GET").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddHeader("Content-Type", "Application/json").
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddHeader("Content-Type", "Application/json").
 		AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
@@ -189,9 +193,10 @@ func TestGoodResponseJSONDeserFailure(t *testing.T) {
 	}))
 	defer server.Close()
 
-	builder := NewRequestBuilder("GET").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddHeader("Content-Type", "Application/json").
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddHeader("Content-Type", "Application/json").
 		AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
@@ -218,9 +223,10 @@ func TestGoodResponseNoBody(t *testing.T) {
 	}))
 	defer server.Close()
 
-	builder := NewRequestBuilder("POST").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddHeader("Content-Type", "Application/json").
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddHeader("Content-Type", "Application/json").
 		AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
@@ -294,9 +300,10 @@ func TestErrorResponseJSON(t *testing.T) {
 	}))
 	defer server.Close()
 
-	builder := NewRequestBuilder("GET").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddHeader("Content-Type", "Application/json").
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddHeader("Content-Type", "Application/json").
 		AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
@@ -327,9 +334,10 @@ func TestErrorResponseJSONDeserError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	builder := NewRequestBuilder("GET").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddHeader("Content-Type", "Application/json").
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddHeader("Content-Type", "Application/json").
 		AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
@@ -356,9 +364,10 @@ func TestErrorResponseNotJSON(t *testing.T) {
 	}))
 	defer server.Close()
 
-	builder := NewRequestBuilder("GET").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddHeader("Content-Type", "Application/json").
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddHeader("Content-Type", "Application/json").
 		AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
@@ -385,9 +394,10 @@ func TestErrorResponseNoBody(t *testing.T) {
 	}))
 	defer server.Close()
 
-	builder := NewRequestBuilder("POST").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddHeader("Content-Type", "Application/json").
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddHeader("Content-Type", "Application/json").
 		AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
@@ -430,9 +440,10 @@ func TestRequestForDefaultUserAgent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	builder := NewRequestBuilder("GET").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddHeader("Content-Type", "Application/json").
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddHeader("Content-Type", "Application/json").
 		AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
@@ -453,9 +464,10 @@ func TestRequestForProvidedUserAgent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	builder := NewRequestBuilder("GET").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddHeader("Content-Type", "Application/json").
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddHeader("Content-Type", "Application/json").
 		AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
@@ -516,12 +528,13 @@ func TestBasicAuth1(t *testing.T) {
 	assert.NotNil(t, service.Options.Authenticator)
 	assert.Equal(t, AUTHTYPE_BASIC, service.Options.Authenticator.AuthenticationType())
 
-	builder := NewRequestBuilder("GET").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddQuery("Version", "2018-22-09")
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
-	_, err := service.Request(req, new(Foo))
+	_, err = service.Request(req, new(Foo))
 	assert.Nil(t, err)
 }
 
@@ -543,9 +556,10 @@ func TestBasicAuth2(t *testing.T) {
 	}))
 	defer server.Close()
 
-	builder := NewRequestBuilder("GET").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddQuery("Version", "2018-22-09")
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
 	options := &ServiceOptions{
@@ -594,9 +608,10 @@ func TestNoAuth1(t *testing.T) {
 	}))
 	defer server.Close()
 
-	builder := NewRequestBuilder("GET").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddQuery("Version", "2018-22-09")
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
 	options := &ServiceOptions{
@@ -621,9 +636,10 @@ func TestNoAuth2(t *testing.T) {
 	}))
 	defer server.Close()
 
-	builder := NewRequestBuilder("GET").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddQuery("Version", "2018-22-09")
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
 	options := &ServiceOptions{
@@ -667,9 +683,10 @@ func TestIAMAuth(t *testing.T) {
 	}))
 	defer server.Close()
 
-	builder := NewRequestBuilder("GET").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddQuery("Version", "2018-22-09")
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
 	options := &ServiceOptions{
@@ -699,9 +716,10 @@ func TestIAMFailure(t *testing.T) {
 	}))
 	defer server.Close()
 
-	builder := NewRequestBuilder("GET").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddQuery("Version", "2018-22-09")
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
 	options := &ServiceOptions{
@@ -743,9 +761,10 @@ func TestIAMWithIdSecret(t *testing.T) {
 	}))
 	defer server.Close()
 
-	builder := NewRequestBuilder("GET").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddQuery("Version", "2018-22-09")
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
 	options := &ServiceOptions{
@@ -828,9 +847,10 @@ func TestCP4DAuth(t *testing.T) {
 	}))
 	defer server.Close()
 
-	builder := NewRequestBuilder("GET").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddQuery("Version", "2018-22-09")
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
 	options := &ServiceOptions{
@@ -857,9 +877,10 @@ func TestCP4DFail(t *testing.T) {
 	}))
 	defer server.Close()
 
-	builder := NewRequestBuilder("GET").
-		ConstructHTTPURL(server.URL, nil, nil).
-		AddQuery("Version", "2018-22-09")
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	builder.AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
 
 	options := &ServiceOptions{
@@ -879,6 +900,7 @@ func TestCP4DFail(t *testing.T) {
 	assert.Equal(t, "Sorry you are forbidden", err.Error())
 }
 
+// Test for the deprecated SetURL method.
 func TestSetURL(t *testing.T) {
 	service, err := NewBaseService(
 		&ServiceOptions{
@@ -891,6 +913,28 @@ func TestSetURL(t *testing.T) {
 
 	err = service.SetURL("{bad url}")
 	assert.NotNil(t, err)
+}
+
+func TestSetServiceURL(t *testing.T) {
+	service, err := NewBaseService(
+		&ServiceOptions{
+			Authenticator: &NoAuthAuthenticator{},
+		}, "watson", "watson")
+	assert.Nil(t, err)
+	assert.NotNil(t, service)
+
+	err = service.SetServiceURL("{bad url}")
+	assert.NotNil(t, err)
+
+	err = service.SetServiceURL("")
+	assert.Nil(t, err)
+	assert.Equal(t, "", service.Options.URL)
+	assert.Equal(t, "", service.GetServiceURL())
+
+	err = service.SetServiceURL("https://myserver.com/api/baseurl")
+	assert.Nil(t, err)
+	assert.Equal(t, "https://myserver.com/api/baseurl", service.Options.URL)
+	assert.Equal(t, "https://myserver.com/api/baseurl", service.GetServiceURL())
 }
 
 func TestExtConfigFromCredentialFile(t *testing.T) {

--- a/core/basic_authenticator_test.go
+++ b/core/basic_authenticator_test.go
@@ -69,9 +69,10 @@ func TestBasicAuthAuthenticate(t *testing.T) {
 	assert.Equal(t, authenticator.AuthenticationType(), AUTHTYPE_BASIC)
 
 	// Create a new Request object.
-	request, err := NewRequestBuilder("GET").
-		ConstructHTTPURL("https://localhost/placeholder/url", nil, nil).
-		Build()
+	builder, err := NewRequestBuilder("GET").ConstructHTTPURL("https://localhost/placeholder/url", nil, nil)
+	assert.Nil(t, err)
+
+	request, err := builder.Build()
 	assert.Nil(t, err)
 	assert.NotNil(t, request)
 

--- a/core/bearer_token_authenticator_test.go
+++ b/core/bearer_token_authenticator_test.go
@@ -40,9 +40,10 @@ func TestBearerTokenAuthenticate(t *testing.T) {
 	assert.Equal(t, authenticator.AuthenticationType(), AUTHTYPE_BEARER_TOKEN)
 
 	// Create a new Request object.
-	request, err := NewRequestBuilder("GET").
-		ConstructHTTPURL("https://localhost/placeholder/url", nil, nil).
-		Build()
+	builder, err := NewRequestBuilder("GET").ConstructHTTPURL("https://localhost/placeholder/url", nil, nil)
+	assert.Nil(t, err)
+
+	request, err := builder.Build()
 	assert.Nil(t, err)
 	assert.NotNil(t, request)
 

--- a/core/cp4d_authenticator.go
+++ b/core/cp4d_authenticator.go
@@ -157,7 +157,10 @@ func (authenticator *CloudPakForDataAuthenticator) requestToken() (*cp4dTokenSer
 		url = fmt.Sprintf("%s%s", url, PRE_AUTH_PATH)
 	}
 
-	builder := NewRequestBuilder(GET).ConstructHTTPURL(url, nil, nil)
+	builder, err := NewRequestBuilder(GET).ConstructHTTPURL(url, nil, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	// Add user-defined headers to request.
 	for headerName, headerValue := range authenticator.Headers {

--- a/core/iam_authenticator.go
+++ b/core/iam_authenticator.go
@@ -176,8 +176,12 @@ func (authenticator *IamAuthenticator) requestToken() (*iamTokenServerResponse, 
 	}
 
 	builder := NewRequestBuilder(POST)
-	builder.ConstructHTTPURL(url, nil, nil).
-		AddHeader(CONTENT_TYPE, DEFAULT_CONTENT_TYPE).
+	_, err := builder.ConstructHTTPURL(url, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	builder.AddHeader(CONTENT_TYPE, DEFAULT_CONTENT_TYPE).
 		AddHeader(Accept, APPLICATION_JSON).
 		AddFormData("grant_type", "", "", REQUEST_TOKEN_GRANT_TYPE).
 		AddFormData("apikey", "", "", authenticator.ApiKey).

--- a/core/noauth_authenticator_test.go
+++ b/core/noauth_authenticator_test.go
@@ -28,9 +28,10 @@ func TestNoAuthAuthenticate(t *testing.T) {
 	assert.Equal(t, authenticator.AuthenticationType(), AUTHTYPE_NOAUTH)
 
 	// Create a new Request object.
-	request, err := NewRequestBuilder("GET").
-		ConstructHTTPURL("https://localhost/placeholder/url", nil, nil).
-		Build()
+	builder, err := NewRequestBuilder("GET").ConstructHTTPURL("https://localhost/placeholder/url", nil, nil)
+	assert.Nil(t, err)
+
+	request, err := builder.Build()
 	assert.Nil(t, err)
 	assert.NotNil(t, request)
 

--- a/core/request_builder.go
+++ b/core/request_builder.go
@@ -45,6 +45,9 @@ const (
 	CONTENT_DISPOSITION     = "Content-Disposition"
 	CONTENT_TYPE            = "Content-Type"
 	FORM_URL_ENCODED_HEADER = "application/x-www-form-urlencoded"
+
+	ERRORMSG_SERVICE_URL_MISSING = "The service URL is required."
+	ERRORMSG_SERVICE_URL_INVALID = "There was an error parsing the service URL: %s"
 )
 
 // A FormData stores information for form data
@@ -74,13 +77,18 @@ func NewRequestBuilder(method string) *RequestBuilder {
 	}
 }
 
-// ConstructHTTPURL creates a properly encoded URL with path parameters.
-func (requestBuilder *RequestBuilder) ConstructHTTPURL(endPoint string, pathSegments []string, pathParameters []string) *RequestBuilder {
+// ConstructHTTPURL creates a properly-encoded URL with path parameters.
+// This function returns an error if the serviceURL is "" or is an
+// invalid URL string (e.g. ":<badscheme>").
+func (requestBuilder *RequestBuilder) ConstructHTTPURL(serviceURL string, pathSegments []string, pathParameters []string) (*RequestBuilder, error) {
+	if serviceURL == "" {
+		return requestBuilder, fmt.Errorf(ERRORMSG_SERVICE_URL_MISSING)
+	}
 	var URL *url.URL
 
-	URL, err := url.Parse(endPoint)
+	URL, err := url.Parse(serviceURL)
 	if err != nil {
-		panic(err)
+		return requestBuilder, fmt.Errorf(ERRORMSG_SERVICE_URL_INVALID, err.Error())
 	}
 
 	for i, pathSegment := range pathSegments {
@@ -90,7 +98,7 @@ func (requestBuilder *RequestBuilder) ConstructHTTPURL(endPoint string, pathSegm
 		}
 	}
 	requestBuilder.URL = URL
-	return requestBuilder
+	return requestBuilder, nil
 }
 
 // AddQuery adds Query name and value


### PR DESCRIPTION
    Fixes arf/planning-sdk-squad#1011
    
    Why:
    In order to support parameterized URLs, we need to defer the validation of
    the service URL value (i.e. myservice.Service.Options.URL) to the point at
    which it is first needed, instead of when the BaseService struct is
    constructed.
    
    What:
    This PR contains changes to support the above, plus the following:
    1) Added comments here and there to some public structs and methods.
    2) Made certain elements within BaseService private since they're not needed
    outside BaseService.
    3) Removed the Version field from the ServiceOptions struct.  Instead, the
    Go generator will be changed to define Version as a field of the generated
    service struct (e.g. AssistantV1) only when the service is detected to
    use a "version param".  The Go core has no use for the Version field as it
    is only ever referenced by the generated service code, so better to move
    the definition of the field there as well.  Plus, we only generate the
    Version-related code if we find that the API definition defines a
    "version param".

Note: There will be a corresponding PR in the Go generator as well.