### PR TITLE
feat(disable ssl): Add description on disabling ssl verification

### DIFF
--- a/core/base_service.go
+++ b/core/base_service.go
@@ -27,10 +27,8 @@ import (
 )
 
 const (
-	header_name_USER_AGENT  = "User-Agent"
-	sdk_name                = "ibm-go-sdk-core"
-	ERROR_MSG_DISABLE_SSL   = "If you're trying to call a service on ICP or Cloud Pak for Data, you may not have a valid SSL certificate. If you need to access the service without setting that up, try using the DisableSSLVerification option in your authentication configuration and/or calling DisableSSLVerification() on your service."
-	SSL_CERTIFICATION_ERROR = "x509: certificate"
+	header_name_USER_AGENT = "User-Agent"
+	sdk_name               = "ibm-go-sdk-core"
 )
 
 // ServiceOptions : This struct contains the options supported by the BaseService methods.
@@ -209,7 +207,7 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 	httpResponse, err := service.Client.Do(req)
 	if err != nil {
 		if strings.Contains(err.Error(), SSL_CERTIFICATION_ERROR) {
-			err = fmt.Errorf(ERROR_MSG_DISABLE_SSL + "\n" + err.Error())
+			err = fmt.Errorf(ERRORMSG_SSL_VERIFICATION_FAILED + "\n" + err.Error())
 		}
 		return
 	}

--- a/core/base_service.go
+++ b/core/base_service.go
@@ -27,8 +27,10 @@ import (
 )
 
 const (
-	header_name_USER_AGENT = "User-Agent"
-	sdk_name               = "ibm-go-sdk-core"
+	header_name_USER_AGENT  = "User-Agent"
+	sdk_name                = "ibm-go-sdk-core"
+	ERROR_MSG_DISABLE_SSL   = "If you're trying to call a service on ICP or Cloud Pak for Data, you may not have a valid SSL certificate. If you need to access the service without setting that up, try using the DisableSSLVerification option in your authentication configuration and/or calling DisableSSLVerification() on your service."
+	SSL_CERTIFICATION_ERROR = "x509: certificate"
 )
 
 // ServiceOptions : This struct contains the options supported by the BaseService methods.
@@ -206,6 +208,9 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 	// Invoke the request.
 	httpResponse, err := service.Client.Do(req)
 	if err != nil {
+		if strings.Contains(err.Error(), SSL_CERTIFICATION_ERROR) {
+			err = fmt.Errorf(ERROR_MSG_DISABLE_SSL + "\n" + err.Error())
+		}
 		return
 	}
 

--- a/core/constants.go
+++ b/core/constants.go
@@ -40,10 +40,14 @@ const (
 	PROPNAME_CLIENT_ID        = "CLIENT_ID"
 	PROPNAME_CLIENT_SECRET    = "CLIENT_SECRET"
 
+	// SSL error
+	SSL_CERTIFICATION_ERROR = "x509: certificate"
+
 	// Common error messages.
-	ERRORMSG_PROP_MISSING     = "The %s property is required but was not specified."
-	ERRORMSG_PROP_INVALID     = "The %s property is invalid. Please remove any surrounding {, }, or \" characters."
-	ERRORMSG_NO_AUTHENTICATOR = "Authentication information was not properly configured."
-	ERRORMSG_AUTHTYPE_UNKNOWN = "Unrecognized authentication type: %s"
-	ERRORMSG_PROPS_MAP_NIL    = "The 'properties' map cannot be nil."
+	ERRORMSG_PROP_MISSING            = "The %s property is required but was not specified."
+	ERRORMSG_PROP_INVALID            = "The %s property is invalid. Please remove any surrounding {, }, or \" characters."
+	ERRORMSG_NO_AUTHENTICATOR        = "Authentication information was not properly configured."
+	ERRORMSG_AUTHTYPE_UNKNOWN        = "Unrecognized authentication type: %s"
+	ERRORMSG_PROPS_MAP_NIL           = "The 'properties' map cannot be nil."
+	ERRORMSG_SSL_VERIFICATION_FAILED = "If you're trying to call a service on ICP or Cloud Pak for Data, you may not have a valid SSL certificate. If you need to access the service without setting that up, try using the DisableSSLVerification option in your authentication configuration and/or calling DisableSSLVerification() on your service."
 )


### PR DESCRIPTION
This PR adds description on how to disable ssl verification.

The error that was thrown was:
```
Get https://blissful-tharp-balancer.fyre.ibm.com:31843/watson/discovery/zen-flunky/instances/1568641354/api/v1/environments: x509: certificate is valid for internal-nginx-svc, *.svc.cluster.local, api-svc, *.api, ibm-nginx-svc, localhost, dsxl-api, not blissful-tharp-balancer.fyre.ibm.com
``` 
from https://golang.org/src/crypto/x509/verify.go

Go doesn't seem to be having specific ways of catching an error, so this seems to be the best I could think of