### PR TITLE
fix: fixed ConstructHTTPURL to avoid '//' when path segment is empty string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ core/coverage.out
 .pre-commit-config.yaml
 .secrets.baseline
 /.settings/
+/.vscode/

--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,4 +1,0 @@
-{
-  "Enable": ["golint"],
-  "Exclude": ["don't use MixedCaps in package name", "should not use dot imports", "don't use ALL_CAPS in Go names; use CamelCase"]
-}

--- a/core/request_builder.go
+++ b/core/request_builder.go
@@ -92,7 +92,10 @@ func (requestBuilder *RequestBuilder) ConstructHTTPURL(serviceURL string, pathSe
 	}
 
 	for i, pathSegment := range pathSegments {
-		URL.Path += "/" + pathSegment
+		if pathSegment != "" {
+			URL.Path += "/" + pathSegment
+		}
+
 		if pathParameters != nil && i < len(pathParameters) {
 			URL.Path += "/" + pathParameters[i]
 		}

--- a/core/request_builder_test.go
+++ b/core/request_builder_test.go
@@ -54,6 +54,17 @@ func TestConstructHTTPURLWithNoPathParam(t *testing.T) {
 	assert.Equal(t, want, request.URL.String(), "Invalid construction of url")
 }
 
+func TestConstructHTTPURLWithEmptyPathSegments(t *testing.T) {
+	endPoint := "https://gateway.watsonplatform.net/assistant/api"
+	pathSegments := []string{"v1/workspaces", "", "segment", ""}
+	pathParameters := []string{"param1", "param2", "param3", "param4"}
+	request := setup()
+	want := "https://gateway.watsonplatform.net/assistant/api/v1/workspaces/param1/param2/segment/param3/param4"
+	_, err := request.ConstructHTTPURL(endPoint, pathSegments, pathParameters)
+	assert.Nil(t, err)
+	assert.Equal(t, want, request.URL.String(), "Invalid construction of url")
+}
+
 func TestConstructHTTPURLMissingURL(t *testing.T) {
 	request := setup()
 	_, err := request.ConstructHTTPURL("", nil, nil)


### PR DESCRIPTION
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/1073

The RequestBuilder.ConstructHTTPURL function was updated so that it doesn't add a "/" to the URL string if the path segment is "".
This could occur if the operation's path contains two consecutive path parameter references, as in:
```
"/v1/resource/{resource_type}/{resource_id}"
```
The VPC API definition defines a couple of paths that fit this pattern.
The API handbook "disallows" this, but we should probably support it nonetheless.