### PR TITLE
fix: fix version.go and .bumpversion.cfg for 1.0.0 release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.0
+current_version = 1.0.0
 commit = True
 message = [skip ci] docs: Update version numbers from {current_version} -> {new_version}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,5 @@ deploy:
   skip_cleanup: true
   script: npx semantic-release --repository-url https://${GH_TOKEN}@github.com/IBM/go-sdk-core
     --debug
+  on:
+    branch: master

--- a/core/version.go
+++ b/core/version.go
@@ -15,4 +15,4 @@ package core
 // limitations under the License.
 
 // Version of the SDK
-const __VERSION__ = "0.8.0"
+const __VERSION__ = "1.0.0"


### PR DESCRIPTION
This PR attempts to fix the mess created by semantic-release/bumpversion where the 1.0.0 version of the go core repo contains a version.go that specifies 0.8.0