### PR TITLE
feat(BaseService): add new method ConfigureService() to BaseService struct

### DIFF
--- a/core/base_service.go
+++ b/core/base_service.go
@@ -88,10 +88,19 @@ func NewBaseService(options *ServiceOptions, serviceName, displayName string) (*
 	// Set a default value for the User-Agent http header.
 	service.SetUserAgent(service.buildUserAgent())
 
+	err := service.ConfigureService(serviceName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &service, nil
+}
+
+func (service *BaseService) ConfigureService(serviceName string) error {
 	// Try to load service properties from external config.
 	serviceProps, err := getServiceProperties(serviceName)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// If we were able to load any properties for this service, then check to see if the
@@ -102,7 +111,7 @@ func NewBaseService(options *ServiceOptions, serviceName, displayName string) (*
 		if url, ok := serviceProps[PROPNAME_SVC_URL]; ok && url != "" {
 			err := service.SetURL(url)
 			if err != nil {
-				return nil, err
+				return err
 			}
 		}
 
@@ -120,8 +129,7 @@ func NewBaseService(options *ServiceOptions, serviceName, displayName string) (*
 			}
 		}
 	}
-
-	return &service, nil
+	return nil
 }
 
 // SetURL sets the service URL

--- a/core/base_service_test.go
+++ b/core/base_service_test.go
@@ -1003,6 +1003,87 @@ func TestExtConfigFromVCAP(t *testing.T) {
 	clearTestVCAP()
 }
 
+func TestConfigureServiceFromCredFile(t *testing.T) {
+	service, err := NewBaseService(
+		&ServiceOptions{
+			Authenticator: &NoAuthAuthenticator{},
+			URL:           "bad url",
+		}, "service_1", "service_1")
+	assert.Nil(t, err)
+	assert.NotNil(t, service)
+	assert.Equal(t, "bad url", service.Options.URL)
+	assert.Nil(t, service.Client.Transport)
+
+	pwd, _ := os.Getwd()
+	credentialFilePath := path.Join(pwd, "/../resources/my-credentials.env")
+	os.Setenv("IBM_CREDENTIALS_FILE", credentialFilePath)
+
+	err = service.ConfigureService("service5")
+	assert.Nil(t, err)
+	assert.NotNil(t, service)
+	assert.Equal(t, "https://service5/api", service.Options.URL)
+	assert.NotNil(t, service.Client.Transport)
+
+	os.Unsetenv("IBM_CREDENTIALS_FILE")
+}
+
+func TestConfigureServiceFromVCAP(t *testing.T) {
+	service, err := NewBaseService(
+		&ServiceOptions{
+			Authenticator: &NoAuthAuthenticator{},
+			URL:           "bad url",
+		}, "service2", "service2")
+	assert.Nil(t, err)
+	assert.NotNil(t, service)
+	assert.Equal(t, "bad url", service.Options.URL)
+
+	setTestVCAP()
+	err = service.ConfigureService("service3")
+	assert.Nil(t, err)
+	assert.NotNil(t, service)
+	assert.Equal(t, "https://service3/api", service.Options.URL)
+	assert.Nil(t, service.Client.Transport)
+
+	clearTestVCAP()
+}
+
+func TestConfigureServiceFromEnv(t *testing.T) {
+	service, err := NewBaseService(
+		&ServiceOptions{
+			Authenticator: &NoAuthAuthenticator{},
+			URL:           "bad url",
+		}, "service_1", "service_1")
+	assert.Nil(t, err)
+	assert.NotNil(t, service)
+	assert.Equal(t, "bad url", service.Options.URL)
+	assert.Nil(t, service.Client.Transport)
+
+	setTestEnvironment()
+	err = service.ConfigureService("service_1")
+	assert.Nil(t, err)
+	assert.NotNil(t, service)
+	assert.Equal(t, "https://service1/api", service.Options.URL)
+	assert.NotNil(t, service.Client.Transport)
+
+	clearTestEnvironment()
+}
+
+func TestConfigureServiceError(t *testing.T) {
+	pwd, _ := os.Getwd()
+	credentialFilePath := path.Join(pwd, "/../resources/my-credentials.env")
+	os.Setenv("IBM_CREDENTIALS_FILE", credentialFilePath)
+
+	service, err := NewBaseService(
+		&ServiceOptions{
+			Authenticator: &NoAuthAuthenticator{},
+			URL:           "bad url",
+		}, "service-1", "service-1")
+	assert.Nil(t, err)
+	err = service.ConfigureService("")
+	assert.NotNil(t, err)
+	os.Unsetenv("IBM_CREDENTIALS_FILE")
+}
+
 func TestAuthNotConfigured(t *testing.T) {
 	service, err := NewBaseService(&ServiceOptions{}, "noauth_service", "noauth_service")
 	assert.NotNil(t, err)


### PR DESCRIPTION
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/1131

Changes:
- moved the external configuration code outside of the constructor into it's own method.
- for compatibility, the constructor calls the new method until we move to the service factory's complete implementation.

The new method will now be invoked from the generator after the BaseService's constructor is called. I have made the method public so it is accessible from the service instance.
