### PR TITLE
fix: add HEAD operation constant

### DIFF
--- a/core/request_builder.go
+++ b/core/request_builder.go
@@ -36,6 +36,7 @@ const (
 	DELETE = http.MethodDelete
 	PUT    = http.MethodPut
 	PATCH  = http.MethodPatch
+	HEAD   = http.MethodHead
 )
 
 // common headers


### PR DESCRIPTION
This adds support for the HEAD method, which is used by an operation in the IAM Access Groups platform service.  Now, operations generated with `core.HEAD` will work as expected.