### PR TITLE
fix: properly support text responses

### DIFF
--- a/core/base_service.go
+++ b/core/base_service.go
@@ -295,9 +295,24 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 			// Decode step was successful. Return the decoded response object in the Result field.
 			detailedResponse.Result = result
 			return
+		} else if IsTextMimeType(contentType) {
+			// For a "text" response, let's just read the response body into a string.
+			
+			// First, read the response body into a byte array.
+			defer httpResponse.Body.Close()
+			responseBody, readErr := ioutil.ReadAll(httpResponse.Body)
+			if readErr != nil {
+				err = fmt.Errorf("An error occurred while reading the response body: '%s'", readErr.Error())
+				return
+			}
+			
+			// Next, create a string containing the response bytes and save it in the Result field.
+			s := string(responseBody[:])
+			detailedResponse.Result = &s
+			return
 		}
 
-		// For a non-JSON response body, just return it as an io.Reader in the Result field.
+		// For a non-JSON/non-Text response body, just return it as an io.Reader in the Result field.
 		detailedResponse.Result = httpResponse.Body
 	}
 

--- a/core/utils.go
+++ b/core/utils.go
@@ -38,6 +38,7 @@ func init() {
 const (
 	jsonMimePattern      = "(?i)^application\\/((json)|(merge\\-patch\\+json))(;.*)?$"
 	jsonPatchMimePattern = "(?i)^application\\/json\\-patch\\+json(;.*)?$"
+	textMimePattern      = "(?i)^text\\/(.+?)(;.*)?$"	
 )
 
 // isNil checks if the specified object is nil or not.
@@ -123,6 +124,19 @@ func IsJSONPatchMimeType(mimeType string) bool {
 		return false
 	}
 	matched, err := regexp.MatchString(jsonPatchMimePattern, mimeType)
+	if err != nil {
+		return false
+	}
+	return matched
+}
+
+// IsTextMimeType Returns true iff the specified mimeType value represents a
+// text mimetype.
+func IsTextMimeType(mimeType string) bool {
+	if mimeType == "" {
+		return false
+	}
+	matched, err := regexp.MatchString(textMimePattern, mimeType)
 	if err != nil {
 		return false
 	}

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -38,6 +38,17 @@ func TestIsJSONPatchMimeType(t *testing.T) {
 	assert.False(t, IsJSONPatchMimeType("YOapplication/json-patch+jsonYO"))
 }
 
+func TestIsTextMimeType(t *testing.T) {
+	assert.True(t, IsTextMimeType("text/html"))
+	assert.True(t, IsTextMimeType("TEXT/PlAiN"))
+	assert.True(t, IsTextMimeType("text/anything;blah"))
+
+	assert.False(t, IsTextMimeType("application/json-patch+patch"))
+	assert.False(t, IsTextMimeType("YOtext/htmlYO"))
+	assert.False(t, IsTextMimeType("application/octet-stream"))
+	assert.False(t, IsTextMimeType("audio/mp3"))
+}
+
 func TestStringNilMapper(t *testing.T) {
 	var s = "test string"
 	assert.Equal(t, "", StringNilMapper(nil))


### PR DESCRIPTION
This PR fixes an issue I found while working on improvements to Go unit test generation in the SDK generator.
Specifically, this PR adds support for receiving a text-based operation response (i.e. a response whose Content-Type header is "text/html" or "text/plain", etc.).  For text-based responses, we would expect the result to be set in the DetailedResponse.Result field as a string.   Prior to this change, text-based responses were incorrectly handled just like a byte-stream type response (i.e. the DetailedResponse.Result field would simply be set to the io.ReadCloser that wraps the bytes contained in the response body).