### PR TITLE
feat: allow JSON response body to be streamed

### DIFF
--- a/core/base_service.go
+++ b/core/base_service.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -269,10 +270,11 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 		return
 	}
 
-	// Operation was successful and we are expecting a response, so de-serialize the response.
+	// Operation was successful and we are expecting a response, so process the response.
 	if result != nil {
 		// For a JSON response, decode it into the response object.
-		if IsJSONMimeType(contentType) {
+		resultType := reflect.TypeOf(result).String()
+		if IsJSONMimeType(contentType) && resultType != "*io.ReadCloser" {
 
 			// First, read the response body into a byte array.
 			defer httpResponse.Body.Close()

--- a/core/detailed_response.go
+++ b/core/detailed_response.go
@@ -33,16 +33,19 @@ type DetailedResponse struct {
 	//
 	// If the operation was successful and the response body contains a JSON response, it is un-marshalled
 	// into an object of the appropriate type (defined by the particular operation), and the Result field will contain
-	// this response object. To retrieve this response object in its properly-typed form, use the
-	// generated service's "Get<operation-name>Result()" method.
-	// If there was an error while un-marshalling the JSON response body, then the RawResult field
+	// this response object.  If there was an error while un-marshalling the JSON response body, then the RawResult field
 	// will be set to the byte array containing the response body.
 	//
-	// If the operation was successful and the response body contains a non-JSON response,
-	// the Result field will be an instance of io.ReadCloser that can be used by the application to read
-	// the response data.
+	// Alternatively, if the generated SDK code passes in a result object which is an io.ReadCloser instance,
+	// the JSON un-marshalling step is bypassed and the response body is simply returned in the Result field.
+	// This scenario would occur in a situation where the SDK would like to provide a streaming model for large JSON
+	// objects.
 	//
-	// If the operation was unsuccessful and the response body contains a JSON response,
+	// If the operation was successful and the response body contains a non-JSON response,
+	// the Result field will be an instance of io.ReadCloser that can be used by generated SDK code 
+	// (or the application) to read the response data.
+	//
+	// If the operation was unsuccessful and the response body contains a JSON error response,
 	// this field will contain an instance of map[string]interface{} which is the result of un-marshalling the
 	// response body as a "generic" JSON object.
 	// If the JSON response for an unsuccessful operation could not be properly un-marshalled, then the


### PR DESCRIPTION
This PR will allow the generated Go code to support a scenario where the decoding of a JSON response body is bypassed with the response body being returned in the DetailedResponse.Result field as an io.ReadCloser instance.
To do this, the generated code would pass in the result of `new(io.ReadCloser)` instead of `new(Foo)` for the deserialization target result object (where Foo represents a model object).