### PR TITLE
Maintain major version # in go.mod file via bump2version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -6,3 +6,9 @@ message = [skip ci] Update version numbers from {current_version} -> {new_versio
 [bumpversion:file:core/version.go]
 search = __VERSION__ = "{current_version}"
 replace = __VERSION__ = "{new_version}"
+
+[bumpversion:file:go.mod]
+parse = (?P<major>\d+)
+serialize = {major}
+search = module github.com/IBM/go-sdk-core/v{current_version}
+replace = module github.com/IBM/go-sdk-core/v{new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,8 @@
 [bumpversion]
-current_version = 3.0.0
-commit = False
+current_version = 3.1.0
+commit = True
 message = [skip ci] Update version numbers from {current_version} -> {new_version}
 
 [bumpversion:file:core/version.go]
 search = __VERSION__ = "{current_version}"
 replace = __VERSION__ = "{new_version}"
-

--- a/.releaserc
+++ b/.releaserc
@@ -1,18 +1,21 @@
 {
-  "branch": "master",
-  "verifyConditions": ["@semantic-release/changelog", "@semantic-release/github"],
   "debug": true,
-  "prepare": [
-    {
-      "path": "@semantic-release/exec",
-      "cmd": "bumpversion --allow-dirty --current-version ${lastRelease.version} --new-version ${nextRelease.version} patch"
-    },
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
-    "@semantic-release/git"
-  ],
-  "publish": [
-    {
-      "path": "@semantic-release/github"
-    }
+    [
+      "@semantic-release/exec", 
+      {
+        "prepareCmd": "bump2version --allow-dirty --current-version ${lastRelease.version} --new-version ${nextRelease.version} patch"
+      }
+    ],
+    [
+      "@semantic-release/git", 
+      {
+        "message": "chore(release): ${nextRelease.version} release notes\n\n${nextRelease.notes}"
+      }
+    ],
+    "@semantic-release/github"
   ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
 - golangci-lint run
 
 before_deploy:
-- pip install --user bumpversion
+- pip install --user bump2version
 - nvm install 12
 - npm install @semantic-release/changelog
 - npm install @semantic-release/exec

--- a/core/version.go
+++ b/core/version.go
@@ -15,4 +15,4 @@ package core
 // limitations under the License.
 
 // Version of the SDK
-const __VERSION__ = "3.0.0"
+const __VERSION__ = "3.1.0"


### PR DESCRIPTION
This PR allows us to use bump2version (a more recent fork of bumpversion) to maintain the major version # within the go.mod file.