### PR TITLE
feat: add unmarshal functions for 'any'

### DIFF
--- a/core/unmarshal.go
+++ b/core/unmarshal.go
@@ -538,6 +538,33 @@ func UnmarshalObjectSlice(m map[string]interface{}, propertyName string) (slice 
 	return
 }
 
+// UnmarshalAny retrieves the specified property from the map and returns it as a generic
+// value (i.e. interface{}), or nil if the property wasn't found in the map.
+func UnmarshalAny(m map[string]interface{}, propertyName string) (result interface{}, err error) {
+	var v interface{}
+	v, foundIt := m[propertyName]
+	if foundIt {
+		result = v
+	}
+	return
+}
+
+// UnmarshalAnySlice retrieves the specified property from the map and returns it as a slice of
+// generic values (i.e. []interface{}), or nil if the property wasn't found in the map.
+func UnmarshalAnySlice(m map[string]interface{}, propertyName string) (slice []interface{}, err error) {
+	v, foundIt := m[propertyName]
+	if foundIt {
+		// Interpret the map value as a slice of anything.
+		vSlice, ok := v.([]interface{})
+		if !ok {
+			err = fmt.Errorf(errorNotAnArray, propertyName, reflect.TypeOf(v).String())
+			return
+		}
+		slice = vSlice
+	}
+	return
+}
+
 // truncateString returns a string suitable for inclusion in an error message.
 // If the input string is longer than the specified length, we'll just return the first <length> 
 // bytes followed by "...".

--- a/core/unmarshal_test.go
+++ b/core/unmarshal_test.go
@@ -616,6 +616,76 @@ func TestUnmarshalObject(t *testing.T) {
 	assert.Nil(t, slice)
 }
 
+func TestUnmarshalAny(t *testing.T) {
+	jsonString := `{
+		"prop1": {"foo": "bar"},
+		"prop2": true,
+		"prop3": 33,
+		"prop4": "a string",
+		"slice1": [
+			{"name": "object1"},
+			{"name": "object2"},
+			{"name": "object3"}
+		],
+		"slice2": [
+		    true,
+		    false
+		],
+		"slice3": [
+		    74,
+		    44
+		],
+		"slice4": [
+		    "football",
+		    "baseball"
+		]
+	}`
+
+	testMap, err := unmarshalJsonToMap(t, jsonString)
+	assert.Nil(t, err)
+	assert.NotNil(t, testMap)
+
+	value, err := UnmarshalAny(testMap, "prop1")
+	assert.Nil(t, err)
+	assert.NotNil(t, value)
+	
+	value, err = UnmarshalAny(testMap, "prop2")
+	assert.Nil(t, err)
+	assert.NotNil(t, value)
+	
+	value, err = UnmarshalAny(testMap, "prop3")
+	assert.Nil(t, err)
+	assert.NotNil(t, value)
+	
+	value, err = UnmarshalAny(testMap, "prop4")
+	assert.Nil(t, err)
+	assert.NotNil(t, value)
+	
+	value, err = UnmarshalAny(testMap, "XXX")
+	assert.Nil(t, err)
+	assert.Nil(t, value)
+
+	slice, err := UnmarshalAnySlice(testMap, "slice1")
+	assert.Nil(t, err)
+	assert.NotNil(t, slice)
+
+	slice, err = UnmarshalAnySlice(testMap, "slice2")
+	assert.Nil(t, err)
+	assert.NotNil(t, slice)
+
+	slice, err = UnmarshalAnySlice(testMap, "slice3")
+	assert.Nil(t, err)
+	assert.NotNil(t, slice)
+
+	slice, err = UnmarshalAnySlice(testMap, "slice4")
+	assert.Nil(t, err)
+	assert.NotNil(t, slice)
+
+	slice, err = UnmarshalAnySlice(testMap, "XXX")
+	assert.Nil(t, err)
+	assert.Nil(t, slice)
+}
+
 // unmarshalJson is a utility function that unmarshals a JSON string into the specified target object in
 // much the same way as the BaseService.Request() method does so that we can simulate that behavior here for testing.
 func unmarshalJson(t *testing.T, jsonString string, target interface{}) (result interface{}, err error) {


### PR DESCRIPTION
This PR is part of the fix for https://github.ibm.com/arf/planning-sdk-squad/issues/1465

This PR adds a couple of extra "Unmarshal" methods for "Any" which will be used by the Go generator for properties associated with an empty schema.