### PR TITLE
fix: tolerate non-compliant error response bodies

### DIFF
--- a/core/base_service.go
+++ b/core/base_service.go
@@ -347,20 +347,31 @@ func getErrorMessage(responseMap map[string]interface{}, statusCode int) string 
 		}
 	}
 
-	// Return the "error" field if present.
+	// Return the "error" field if present and is a string.
 	if val, ok := responseMap["error"]; ok {
-		return val.(string)
+		errorMsg, ok := val.(string)
+		if ok {
+			return errorMsg
+		}
 	}
 
-	// Return the "message" field if present.
+	// Return the "message" field if present and is a string.
 	if val, ok := responseMap["message"]; ok {
-		return val.(string)
+		errorMsg, ok := val.(string)
+		if ok {
+			return errorMsg
+		}
 	}
 
-	// Finally, return the "errorMessage" field if present.
+	// Finally, return the "errorMessage" field if present and is a string.
 	if val, ok := responseMap["errorMessage"]; ok {
-		return val.(string)
+		errorMsg, ok := val.(string)
+		if ok {
+			return errorMsg
+		}
 	}
 
+	// If we couldn't find an error message above, just return the generic text
+	// for the status code.
 	return http.StatusText(statusCode)
 }

--- a/core/base_service_test.go
+++ b/core/base_service_test.go
@@ -1197,4 +1197,16 @@ func TestErrorMessage(t *testing.T) {
 	testGetErrorMessage(t, http.StatusForbidden, `{"msg":"error4"}`, http.StatusText(http.StatusForbidden))
 
 	testGetErrorMessage(t, http.StatusBadRequest, `{"errorMessage":"error5"}`, "error5")
+	
+	testGetErrorMessage(t, http.StatusInternalServerError, 
+		`{"error":{"statusCode":500,"message":"Internal Server Error"}}`,
+		"Internal Server Error")	
+	
+	testGetErrorMessage(t, http.StatusInternalServerError, 
+		`{"message":{"statusCode":500,"message":"Internal Server Error"}}`,
+		"Internal Server Error")	
+	
+	testGetErrorMessage(t, http.StatusInternalServerError, 
+		`{"errorMessage":{"statusCode":500,"message":"Internal Server Error"}}`,
+		"Internal Server Error")	
 }


### PR DESCRIPTION
This PR backports the fix for issue 1483 to the v2.x release stream.