### PR TITLE
Fix caching of access tokens

### DIFF
--- a/core/base_service_test.go
+++ b/core/base_service_test.go
@@ -758,11 +758,11 @@ func TestIAMAuth(t *testing.T) {
 			assert.Equal(t, true, firstCall)
 			firstCall = false
 			expiration := GetCurrentTime() + 3600
-			fmt.Fprint(w, `{
+			fmt.Fprintf(w, `{
 				"access_token": "captain marvel",
 				"token_type": "Bearer",
 				"expires_in": 3600,
-				"expiration": 1524167011,
+				"expiration": %d,
 				"refresh_token": "jy4gl91BQ"
 			}`, expiration)
 			assert.Equal(t, "", r.Header.Get("Authorization"))

--- a/core/basic_authenticator.go
+++ b/core/basic_authenticator.go
@@ -64,7 +64,7 @@ func (BasicAuthenticator) AuthenticationType() string {
 //
 // 		Authorization: Basic <encoded username and password>
 //
-func (this BasicAuthenticator) Authenticate(request *http.Request) error {
+func (this *BasicAuthenticator) Authenticate(request *http.Request) error {
 	request.SetBasicAuth(this.Username, this.Password)
 	return nil
 }

--- a/core/bearer_token_authenticator.go
+++ b/core/bearer_token_authenticator.go
@@ -61,7 +61,7 @@ func (BearerTokenAuthenticator) AuthenticationType() string {
 //
 // 		Authorization: Bearer <bearer-token>
 //
-func (this BearerTokenAuthenticator) Authenticate(request *http.Request) error {
+func (this *BearerTokenAuthenticator) Authenticate(request *http.Request) error {
 	request.Header.Set("Authorization", fmt.Sprintf(`Bearer %s`, this.BearerToken))
 	return nil
 }

--- a/core/cp4d_authenticator.go
+++ b/core/cp4d_authenticator.go
@@ -133,7 +133,7 @@ func (authenticator CloudPakForDataAuthenticator) Validate() error {
 //
 // 		Authorization: Bearer <bearer-token>
 //
-func (authenticator CloudPakForDataAuthenticator) Authenticate(request *http.Request) error {
+func (authenticator *CloudPakForDataAuthenticator) Authenticate(request *http.Request) error {
 	token, err := authenticator.getToken()
 	if err != nil {
 		return err

--- a/core/iam_authenticator.go
+++ b/core/iam_authenticator.go
@@ -126,7 +126,7 @@ func (IamAuthenticator) AuthenticationType() string {
 //
 // 		Authorization: Bearer <bearer-token>
 //
-func (authenticator IamAuthenticator) Authenticate(request *http.Request) error {
+func (authenticator *IamAuthenticator) Authenticate(request *http.Request) error {
 	token, err := authenticator.getToken()
 	if err != nil {
 		return err

--- a/core/noauth_authenticator.go
+++ b/core/noauth_authenticator.go
@@ -35,7 +35,7 @@ func (NoAuthAuthenticator) Validate() error {
 	return nil
 }
 
-func (this NoAuthAuthenticator) Authenticate(request *http.Request) error {
+func (this *NoAuthAuthenticator) Authenticate(request *http.Request) error {
 	// Nothing to do since we're not providing any authentication.
 	return nil
 }


### PR DESCRIPTION
This PR makes a small but important fix to the IAM and CP4D authenticators that fixes the way tokens are cached for future use.  Previously, the `authenticator` passed to the `Authenticate` method was passed by value, and when the token was stored into this authenticator, it was lost when the `Authenticate` method returned.  The fix is to pass the authenticator to `Authenticate` _by reference_, so that the token is stored in the caller's `authenticator` object and then available for subsequent calls.