### PR TITLE
fix: tolerate explicit JSON null values in UnmarshalXXX() methods

### DIFF
--- a/core/unmarshal.go
+++ b/core/unmarshal.go
@@ -77,7 +77,7 @@ func CopyMap(m map[string]interface{}) map[string]interface{} {
 func UnmarshalString(m map[string]interface{}, propertyName string) (result *string, err error) {
 	var v interface{}
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a string.
 		s, ok := v.(string)
 		if ok {
@@ -94,7 +94,7 @@ func UnmarshalString(m map[string]interface{}, propertyName string) (result *str
 func UnmarshalStringSlice(m map[string]interface{}, propertyName string) (slice []string, err error) {
 	var v interface{}
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a slice of anything.
 		vSlice, ok := v.([]interface{})
 		if !ok {
@@ -119,7 +119,7 @@ func UnmarshalStringSlice(m map[string]interface{}, propertyName string) (slice 
 func UnmarshalByteArray(m map[string]interface{}, propertyName string) (result *[]byte, err error) {
 	var v interface{}
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a string.
 		s, ok := v.(string)
 		if ok {
@@ -143,7 +143,7 @@ func UnmarshalByteArray(m map[string]interface{}, propertyName string) (result *
 func UnmarshalByteArraySlice(m map[string]interface{}, propertyName string) (slice [][]byte, err error) {
 	var v interface{}
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a slice of anything.
 		vSlice, ok := v.([]interface{})
 		if ok {
@@ -176,7 +176,7 @@ func UnmarshalByteArraySlice(m map[string]interface{}, propertyName string) (sli
 func UnmarshalBool(m map[string]interface{}, propertyName string) (result *bool, err error) {
 	var v interface{}
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a bool.
 		b, ok := v.(bool)
 		if ok {
@@ -193,7 +193,7 @@ func UnmarshalBool(m map[string]interface{}, propertyName string) (result *bool,
 func UnmarshalBoolSlice(m map[string]interface{}, propertyName string) (slice []bool, err error) {
 	var v interface{}
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a slice of anything.
 		vSlice, ok := v.([]interface{})
 		if !ok {
@@ -218,7 +218,7 @@ func UnmarshalBoolSlice(m map[string]interface{}, propertyName string) (slice []
 func UnmarshalInt64(m map[string]interface{}, propertyName string) (result *int64, err error) {
 	var v interface{}
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a float64 to match the behavior of the JSON unmarshaller.
 		f, ok := v.(float64)
 		if ok {
@@ -236,7 +236,7 @@ func UnmarshalInt64(m map[string]interface{}, propertyName string) (result *int6
 func UnmarshalInt64Slice(m map[string]interface{}, propertyName string) (slice []int64, err error) {
 	var v interface{}
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a slice of anything.
 		vSlice, ok := v.([]interface{})
 		if !ok {
@@ -261,7 +261,7 @@ func UnmarshalInt64Slice(m map[string]interface{}, propertyName string) (slice [
 func UnmarshalFloat32(m map[string]interface{}, propertyName string) (result *float32, err error) {
 	var v interface{}
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a float64 to match the behavior of the JSON unmarshaller.
 		f, ok := v.(float64)
 		if ok {
@@ -279,7 +279,7 @@ func UnmarshalFloat32(m map[string]interface{}, propertyName string) (result *fl
 func UnmarshalFloat32Slice(m map[string]interface{}, propertyName string) (slice []float32, err error) {
 	var v interface{}
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a slice of anything.
 		vSlice, ok := v.([]interface{})
 		if !ok {
@@ -304,7 +304,7 @@ func UnmarshalFloat32Slice(m map[string]interface{}, propertyName string) (slice
 func UnmarshalFloat64(m map[string]interface{}, propertyName string) (result *float64, err error) {
 	var v interface{}
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a float64.
 		f, ok := v.(float64)
 		if ok {
@@ -321,7 +321,7 @@ func UnmarshalFloat64(m map[string]interface{}, propertyName string) (result *fl
 func UnmarshalFloat64Slice(m map[string]interface{}, propertyName string) (slice []float64, err error) {
 	var v interface{}
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a slice of anything.
 		vSlice, ok := v.([]interface{})
 		if !ok {
@@ -346,7 +346,7 @@ func UnmarshalFloat64Slice(m map[string]interface{}, propertyName string) (slice
 func UnmarshalUUID(m map[string]interface{}, propertyName string) (result *strfmt.UUID, err error) {
 	var v interface{}
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a string.
 		s, ok := v.(string)
 		if ok {
@@ -365,7 +365,7 @@ func UnmarshalUUID(m map[string]interface{}, propertyName string) (result *strfm
 func UnmarshalUUIDSlice(m map[string]interface{}, propertyName string) (slice []strfmt.UUID, err error) {
 	var v interface{}
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a slice of anything.
 		vSlice, ok := v.([]interface{})
 		if !ok {
@@ -390,7 +390,7 @@ func UnmarshalUUIDSlice(m map[string]interface{}, propertyName string) (slice []
 func UnmarshalDate(m map[string]interface{}, propertyName string) (result *strfmt.Date, err error) {
 	var v interface{}
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a string.
 		s, ok := v.(string)
 		if ok {
@@ -414,7 +414,7 @@ func UnmarshalDate(m map[string]interface{}, propertyName string) (result *strfm
 func UnmarshalDateSlice(m map[string]interface{}, propertyName string) (slice []strfmt.Date, err error) {
 	var v interface{}
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a slice of anything.
 		vSlice, ok := v.([]interface{})
 		if !ok {
@@ -446,7 +446,7 @@ func UnmarshalDateSlice(m map[string]interface{}, propertyName string) (slice []
 func UnmarshalDateTime(m map[string]interface{}, propertyName string) (result *strfmt.DateTime, err error) {
 	var v interface{}
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a string.
 		s, ok := v.(string)
 		if ok {
@@ -470,7 +470,7 @@ func UnmarshalDateTime(m map[string]interface{}, propertyName string) (result *s
 func UnmarshalDateTimeSlice(m map[string]interface{}, propertyName string) (slice []strfmt.DateTime, err error) {
 	var v interface{}
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a slice of anything.
 		vSlice, ok := v.([]interface{})
 		if !ok {
@@ -502,7 +502,7 @@ func UnmarshalDateTimeSlice(m map[string]interface{}, propertyName string) (slic
 func UnmarshalObject(m map[string]interface{}, propertyName string) (result map[string]interface{}, err error) {
 	var v interface{}
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a generic map containing a JSON object.
 		jsonMap, ok := v.(map[string]interface{})
 		if ok {
@@ -518,7 +518,7 @@ func UnmarshalObject(m map[string]interface{}, propertyName string) (result map[
 // generic objects (i.e. []map[string]interface{}), or nil if the property wasn't found in the map.
 func UnmarshalObjectSlice(m map[string]interface{}, propertyName string) (slice []map[string]interface{}, err error) {
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a slice of anything.
 		vSlice, ok := v.([]interface{})
 		if !ok {
@@ -543,7 +543,7 @@ func UnmarshalObjectSlice(m map[string]interface{}, propertyName string) (slice 
 func UnmarshalAny(m map[string]interface{}, propertyName string) (result interface{}, err error) {
 	var v interface{}
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		result = v
 	}
 	return
@@ -553,7 +553,7 @@ func UnmarshalAny(m map[string]interface{}, propertyName string) (result interfa
 // generic values (i.e. []interface{}), or nil if the property wasn't found in the map.
 func UnmarshalAnySlice(m map[string]interface{}, propertyName string) (slice []interface{}, err error) {
 	v, foundIt := m[propertyName]
-	if foundIt {
+	if foundIt && v != nil {
 		// Interpret the map value as a slice of anything.
 		vSlice, ok := v.([]interface{})
 		if !ok {

--- a/core/unmarshal_test.go
+++ b/core/unmarshal_test.go
@@ -52,7 +52,9 @@ func TestUnmarshalString(t *testing.T) {
 		"slice1": ["string1", "string2"],
 		"incorrect_type":  true,
 		"not_a_slice": false,
-		"incorrect_slice_type": [38, 26]
+		"incorrect_slice_type": [38, 26],
+		"null_prop": null,
+		"null_slice": null
 	}`
 
 	testMap, err := unmarshalJsonToMap(t, jsonString)
@@ -71,6 +73,10 @@ func TestUnmarshalString(t *testing.T) {
 	t.Logf("Expected error: %s\n", err.Error())
 
 	value, err = UnmarshalString(testMap, "XXX")
+	assert.Nil(t, err)
+	assert.Nil(t, value)
+
+	value, err = UnmarshalString(testMap, "null_prop")
 	assert.Nil(t, err)
 	assert.Nil(t, value)
 
@@ -94,6 +100,10 @@ func TestUnmarshalString(t *testing.T) {
 	slice, err = UnmarshalStringSlice(testMap, "XXX")
 	assert.Nil(t, err)
 	assert.Nil(t, slice)
+
+	slice, err = UnmarshalStringSlice(testMap, "null_slice")
+	assert.Nil(t, err)
+	assert.Nil(t, slice)
 }
 
 func TestUnmarshalByteArray(t *testing.T) {
@@ -107,7 +117,9 @@ func TestUnmarshalByteArray(t *testing.T) {
 		"not_a_slice": false,
 		"incorrect_slice_type": [38, 26],
 		"invalid_byte_array": "this is not an encoded string!",
-		"invalid_byte_array_slice": ["this is not an encoded string!"]
+		"invalid_byte_array_slice": ["this is not an encoded string!"],
+		"null_prop": null,
+		"null_slice": null
 	}`
 	jsonString := fmt.Sprintf(jsonTemplate, encodedString, encodedString, encodedString)
 
@@ -133,6 +145,10 @@ func TestUnmarshalByteArray(t *testing.T) {
 	t.Logf("Expected error: %s\n", err.Error())
 
 	value, err = UnmarshalByteArray(testMap, "XXX")
+	assert.Nil(t, err)
+	assert.Nil(t, value)
+
+	value, err = UnmarshalByteArray(testMap, "null_prop")
 	assert.Nil(t, err)
 	assert.Nil(t, value)
 
@@ -162,6 +178,10 @@ func TestUnmarshalByteArray(t *testing.T) {
 	slice, err = UnmarshalByteArraySlice(testMap, "XXX")
 	assert.Nil(t, err)
 	assert.Nil(t, slice)
+
+	slice, err = UnmarshalByteArraySlice(testMap, "null_slice")
+	assert.Nil(t, err)
+	assert.Nil(t, slice)
 }
 
 func TestUnmarshalBool(t *testing.T) {
@@ -170,7 +190,9 @@ func TestUnmarshalBool(t *testing.T) {
 		"slice1": [false, true],
 		"incorrect_type": "true",
 		"not_a_slice": false,
-		"incorrect_slice_type": [38, 26]
+		"incorrect_slice_type": [38, 26],
+		"null_prop": null,
+		"null_slice": null
 	}`
 
 	testMap, err := unmarshalJsonToMap(t, jsonString)
@@ -189,6 +211,10 @@ func TestUnmarshalBool(t *testing.T) {
 	t.Logf("Expected error: %s\n", err.Error())
 
 	value, err = UnmarshalBool(testMap, "XXX")
+	assert.Nil(t, err)
+	assert.Nil(t, value)
+
+	value, err = UnmarshalBool(testMap, "null_prop")
 	assert.Nil(t, err)
 	assert.Nil(t, value)
 
@@ -212,6 +238,10 @@ func TestUnmarshalBool(t *testing.T) {
 	slice, err = UnmarshalBoolSlice(testMap, "XXX")
 	assert.Nil(t, err)
 	assert.Nil(t, slice)
+
+	slice, err = UnmarshalBoolSlice(testMap, "null_slice")
+	assert.Nil(t, err)
+	assert.Nil(t, slice)
 }
 
 func TestUnmarshalInt64(t *testing.T) {
@@ -220,7 +250,9 @@ func TestUnmarshalInt64(t *testing.T) {
 		"slice1": [74, 44],
 		"incorrect_type":  true,
 		"not_a_slice": false,
-		"incorrect_slice_type": ["blah"]
+		"incorrect_slice_type": ["blah"],
+		"null_prop": null,
+		"null_slice": null
 	}`
 
 	testMap, err := unmarshalJsonToMap(t, jsonString)
@@ -239,6 +271,10 @@ func TestUnmarshalInt64(t *testing.T) {
 	t.Logf("Expected error: %s\n", err.Error())
 
 	value, err = UnmarshalInt64(testMap, "XXX")
+	assert.Nil(t, err)
+	assert.Nil(t, value)
+
+	value, err = UnmarshalInt64(testMap, "null_prop")
 	assert.Nil(t, err)
 	assert.Nil(t, value)
 
@@ -262,6 +298,10 @@ func TestUnmarshalInt64(t *testing.T) {
 	slice, err = UnmarshalInt64Slice(testMap, "XXX")
 	assert.Nil(t, err)
 	assert.Nil(t, slice)
+
+	slice, err = UnmarshalInt64Slice(testMap, "null_slice")
+	assert.Nil(t, err)
+	assert.Nil(t, slice)
 }
 
 func TestUnmarshalFloat64(t *testing.T) {
@@ -270,7 +310,9 @@ func TestUnmarshalFloat64(t *testing.T) {
 		"slice1": [74.5, 44.8],
 		"incorrect_type":  true,
 		"not_a_slice": false,
-		"incorrect_slice_type": ["blah"]
+		"incorrect_slice_type": ["blah"],
+		"null_prop": null,
+		"null_slice": null
 	}`
 
 	testMap, err := unmarshalJsonToMap(t, jsonString)
@@ -289,6 +331,10 @@ func TestUnmarshalFloat64(t *testing.T) {
 	t.Logf("Expected error: %s\n", err.Error())
 
 	value, err = UnmarshalFloat64(testMap, "XXX")
+	assert.Nil(t, err)
+	assert.Nil(t, value)
+
+	value, err = UnmarshalFloat64(testMap, "null_prop")
 	assert.Nil(t, err)
 	assert.Nil(t, value)
 
@@ -312,6 +358,10 @@ func TestUnmarshalFloat64(t *testing.T) {
 	slice, err = UnmarshalFloat64Slice(testMap, "XXX")
 	assert.Nil(t, err)
 	assert.Nil(t, slice)
+
+	slice, err = UnmarshalFloat64Slice(testMap, "null_slice")
+	assert.Nil(t, err)
+	assert.Nil(t, slice)
 }
 
 func TestUnmarshalFloat32(t *testing.T) {
@@ -320,7 +370,9 @@ func TestUnmarshalFloat32(t *testing.T) {
 		"slice1": [74.5, 44.8],
 		"incorrect_type":  true,
 		"not_a_slice": false,
-		"incorrect_slice_type": ["blah"]
+		"incorrect_slice_type": ["blah"],
+		"null_prop": null,
+		"null_slice": null
 	}`
 
 	testMap, err := unmarshalJsonToMap(t, jsonString)
@@ -339,6 +391,10 @@ func TestUnmarshalFloat32(t *testing.T) {
 	t.Logf("Expected error: %s\n", err.Error())
 
 	value, err = UnmarshalFloat32(testMap, "XXX")
+	assert.Nil(t, err)
+	assert.Nil(t, value)
+
+	value, err = UnmarshalFloat32(testMap, "null_prop")
 	assert.Nil(t, err)
 	assert.Nil(t, value)
 
@@ -362,6 +418,10 @@ func TestUnmarshalFloat32(t *testing.T) {
 	slice, err = UnmarshalFloat32Slice(testMap, "XXX")
 	assert.Nil(t, err)
 	assert.Nil(t, slice)
+
+	slice, err = UnmarshalFloat32Slice(testMap, "null_slice")
+	assert.Nil(t, err)
+	assert.Nil(t, slice)
 }
 
 func TestUnmarshalUUID(t *testing.T) {
@@ -373,7 +433,9 @@ func TestUnmarshalUUID(t *testing.T) {
 		"slice1": ["%s","%s"],
 		"incorrect_type": true,
 		"not_a_slice": false,
-		"incorrect_slice_type": [true, false]
+		"incorrect_slice_type": [true, false],
+		"null_prop": null,
+		"null_slice": null
 	}`
 	jsonString := fmt.Sprintf(jsonTemplate, uuid1, uuid1, uuid2)
 
@@ -393,6 +455,10 @@ func TestUnmarshalUUID(t *testing.T) {
 	t.Logf("Expected error: %s\n", err.Error())
 
 	value, err = UnmarshalUUID(testMap, "XXX")
+	assert.Nil(t, err)
+	assert.Nil(t, value)
+
+	value, err = UnmarshalUUID(testMap, "null_prop")
 	assert.Nil(t, err)
 	assert.Nil(t, value)
 
@@ -417,6 +483,10 @@ func TestUnmarshalUUID(t *testing.T) {
 	slice, err = UnmarshalUUIDSlice(testMap, "XXX")
 	assert.Nil(t, err)
 	assert.Nil(t, slice)
+
+	slice, err = UnmarshalUUIDSlice(testMap, "null_slice")
+	assert.Nil(t, err)
+	assert.Nil(t, slice)
 }
 
 func TestUnmarshalDate(t *testing.T) {
@@ -430,7 +500,9 @@ func TestUnmarshalDate(t *testing.T) {
 		"not_a_slice": false,
 		"incorrect_slice_type": [true, false],
 		"invalid_date": "this is not a valid date",
-		"invalid_date_slice": ["another invalid date value"]
+		"invalid_date_slice": ["another invalid date value"],
+		"null_prop": null,
+		"null_slice": null
 	}`
 	jsonString := fmt.Sprintf(jsonTemplate, date1, date1, date2)
 
@@ -456,6 +528,10 @@ func TestUnmarshalDate(t *testing.T) {
 	t.Logf("Expected error: %s\n", err.Error())
 
 	value, err = UnmarshalDate(testMap, "XXX")
+	assert.Nil(t, err)
+	assert.Nil(t, value)
+
+	value, err = UnmarshalDate(testMap, "null_prop")
 	assert.Nil(t, err)
 	assert.Nil(t, value)
 
@@ -486,6 +562,10 @@ func TestUnmarshalDate(t *testing.T) {
 	slice, err = UnmarshalDateSlice(testMap, "XXX")
 	assert.Nil(t, err)
 	assert.Nil(t, slice)
+
+	slice, err = UnmarshalDateSlice(testMap, "null_slice")
+	assert.Nil(t, err)
+	assert.Nil(t, slice)
 }
 
 func TestUnmarshalDateTime(t *testing.T) {
@@ -500,7 +580,9 @@ func TestUnmarshalDateTime(t *testing.T) {
 		"not_a_slice": false,
 		"incorrect_slice_type": [true, false],
 		"invalid_datetime": "this is an invalid datetime value",
-		"invalid_datetime_slice": ["another invalid datetime value"]
+		"invalid_datetime_slice": ["another invalid datetime value"],
+		"null_prop": null,
+		"null_slice": null
 	}`
 	jsonString := fmt.Sprintf(jsonTemplate, datetime1, datetime2, datetime3)
 
@@ -529,6 +611,10 @@ func TestUnmarshalDateTime(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, value)
 
+	value, err = UnmarshalDateTime(testMap, "null_prop")
+	assert.Nil(t, err)
+	assert.Nil(t, value)
+
 	slice, err := UnmarshalDateTimeSlice(testMap, "slice1")
 	assert.Nil(t, err)
 	assert.NotNil(t, slice)
@@ -554,8 +640,11 @@ func TestUnmarshalDateTime(t *testing.T) {
 	assert.True(t, strings.Contains(err.Error(), "error decoding"))
 	t.Logf("Expected error: %s\n", err.Error())
 
-
 	slice, err = UnmarshalDateTimeSlice(testMap, "XXX")
+	assert.Nil(t, err)
+	assert.Nil(t, slice)
+
+	slice, err = UnmarshalDateTimeSlice(testMap, "null_slice")
 	assert.Nil(t, err)
 	assert.Nil(t, slice)
 }
@@ -570,7 +659,9 @@ func TestUnmarshalObject(t *testing.T) {
 		],
 		"incorrect_type":  true,
 		"not_a_slice": false,
-		"incorrect_slice_type": [false]
+		"incorrect_slice_type": [false],
+		"null_prop": null,
+		"null_slice": null
 	}`
 
 	testMap, err := unmarshalJsonToMap(t, jsonString)
@@ -589,6 +680,10 @@ func TestUnmarshalObject(t *testing.T) {
 	t.Logf("Expected error: %s\n", err.Error())
 
 	value, err = UnmarshalObject(testMap, "XXX")
+	assert.Nil(t, err)
+	assert.Nil(t, value)
+
+	value, err = UnmarshalObject(testMap, "null_prop")
 	assert.Nil(t, err)
 	assert.Nil(t, value)
 
@@ -612,6 +707,10 @@ func TestUnmarshalObject(t *testing.T) {
 	t.Logf("Expected error: %s\n", err.Error())
 
 	slice, err = UnmarshalObjectSlice(testMap, "XXX")
+	assert.Nil(t, err)
+	assert.Nil(t, slice)
+
+	slice, err = UnmarshalObjectSlice(testMap, "null_slice")
 	assert.Nil(t, err)
 	assert.Nil(t, slice)
 }
@@ -638,7 +737,9 @@ func TestUnmarshalAny(t *testing.T) {
 		"slice4": [
 		    "football",
 		    "baseball"
-		]
+		],
+		"null_prop": null,
+		"null_slice": null
 	}`
 
 	testMap, err := unmarshalJsonToMap(t, jsonString)
@@ -664,6 +765,10 @@ func TestUnmarshalAny(t *testing.T) {
 	value, err = UnmarshalAny(testMap, "XXX")
 	assert.Nil(t, err)
 	assert.Nil(t, value)
+	
+	value, err = UnmarshalAny(testMap, "null_prop")
+	assert.Nil(t, err)
+	assert.Nil(t, value)
 
 	slice, err := UnmarshalAnySlice(testMap, "slice1")
 	assert.Nil(t, err)
@@ -682,6 +787,10 @@ func TestUnmarshalAny(t *testing.T) {
 	assert.NotNil(t, slice)
 
 	slice, err = UnmarshalAnySlice(testMap, "XXX")
+	assert.Nil(t, err)
+	assert.Nil(t, slice)
+
+	slice, err = UnmarshalAnySlice(testMap, "null_slice")
 	assert.Nil(t, err)
 	assert.Nil(t, slice)
 }


### PR DESCRIPTION
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/1517
Fixes: https://github.ibm.com/ibmcloud/platform-services-go-sdk/issues/14

This PR adds an explicit nil check when retrieving properties from a map inside the various UnmarshalXXX() methods.   Previously, we were checking for the existence of the property in the map, but did not consider the possibility that the value of the property is the JSON null value.