### PR TITLE
feat(unmarshal): introduce new unmarshal functions for primitives and models

### DIFF
--- a/core/unmarshal_v2.go
+++ b/core/unmarshal_v2.go
@@ -1,0 +1,521 @@
+/**
+ * (C) Copyright IBM Corp. 2020.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+const (
+	errorPropertyInsert          = " property '%s' as"
+	errorPropertyNameMissing     = "the 'propertyName' parameter is required"
+	errorUnmarshalPrimitive      = "error unmarshalling property '%s': %s"
+	errorUnmarshalModel          = "error unmarshalling%s %s: %s"
+	errorIncorrectInputType      = "expected 'rawInput' to be a %s but was %s"
+	errorUnsupportedMapEntryType = "unsupported map entry type: %s"
+	errorUnsupportedResultType   = "unsupported 'result' type: %s"
+)
+
+//
+// UnmarshalPrimitive retrieves the specified property from 'rawInput',
+// then unmarshals the resulting value into 'result'.
+//
+// This function will typically be invoked from within a model's generated "Unmarshal<model>()" method to unmarshal
+// a struct field (model property) involving a primitive type (a scalar value, a slice, a map of the primitive, etc.).
+// In this context, "primitive" refers to a type other than a user-defined model type within an OpenAPI definition.
+// The 'rawInput' parameter is expected to be a map that contains an instance of a user-defined model type.
+//
+// Parameters:
+//
+// rawInput: the unmarshal input source in the form of a map[string]json.RawMessage
+// The value 'rawInput[propertyName]' must be a json.RawMessage that contains an instance of the type inferred
+// from the value passed in as 'result'.
+//
+// propertyName: the name of the property (map entry) to retrieve from 'rawInput'. This entry's value will
+// be used as the unmarshal input source.
+//
+// result: a pointer to the unmarshal destination. This could be any of the following:
+//   - **<primitive-type>
+//   - *[]<primitive-type>
+//   - *map[string]<primitive-type>
+//   - *map[string][]<primitive-type>
+//   - *[]map[string]<primitive-type>
+//   - *[]map[string][]<primitive-type>
+//
+// Where <primitive-type> could be any of the following:
+//   - string, bool, []byte, int64, float32, float64, strfmt.Date, strfmt.DateTime,
+//     strfmt.UUID, interface{}, or map[string]interface{}.
+//
+// Example:
+// type MyStruct struct {
+//     Field1 *string,
+//     Field2 map[string]int64
+// }
+// myStruct := new(MyStruct)
+// jsonString := `{ "field1": "value1", "field2": {"foo": 44, "bar": 74}}`
+// var rawMessageMap map[string]json.RawMessage
+// var err error
+// err = UnmarshalPrimitive(rawMessageMap, "field1", &myStruct.Field1)
+// err = UnmarshalPrimitive(rawMessageMap, "field2", &myString.Field2)
+//
+func UnmarshalPrimitive(rawInput map[string]json.RawMessage, propertyName string, result interface{}) (err error) {
+	if propertyName == "" {
+		err = fmt.Errorf(errorPropertyNameMissing)
+	}
+	
+	rawMsg, foundIt := rawInput[propertyName]
+	if foundIt && rawMsg != nil {
+		err = json.Unmarshal(rawMsg, result)
+		if err != nil {
+			err = fmt.Errorf(errorUnmarshalPrimitive, propertyName, err.Error())
+		}
+	}
+	return
+}
+
+//
+// ModelUnmarshaller defines the interface for a generated Unmarshal<model>() function, which is used
+// by the various "UnmarshalModel" functions below to unmarshal an instance of the user-defined model type.
+//
+// Parameters:
+// rawInput: a map[string]json.RawMessage that is assumed to contain an instance of the model type.
+//
+// result: the unmarshal destination.  This should be a **<model> (i.e. a ptr to a ptr to a model instance).
+// A new instance of the model is constructed by the unmarshaller function and is returned through the ptr
+// passed in as 'result'.
+//
+type ModelUnmarshaller func(rawInput map[string]json.RawMessage, result interface{}) error
+
+//
+// UnmarshalModel unmarshals 'rawInput' into 'result' while using 'unmarshaller' to unmarshal model instances.
+// This function is the single public interface to the various flavors of model-related unmarshal functions.
+// The values passed in for the 'rawInput', 'propertyName' and 'result' fields will determine the function performed.
+// 
+// Parameters:
+// rawInput: the unmarshal input source.  The various types associated with this parameter are described below in
+// "Usage Notes".
+// 
+// propertyName: an optional property name.  If specified as "", then 'rawInput' is assumed to directly contain 
+// the input source to be used for the unmarshal operation.
+// If propertyName is specified as a non-empty string, then 'rawInput' is assumed to be a map[string]json.RawMessage,
+// and rawInput[propertyName] contains the input source to be unmarshalled.
+//
+// result: the unmarshal destination.  This should be passed in as one of the following types of values:
+//   - **<model> (a ptr to a ptr to a <model> instance)
+//   - *[]<model> (a ptr to a <model> slice)
+//   - *map[string]<model> (a ptr to a map of <model> instances)
+//   - *map[string][]<model> (a ptr to a map of <model> slices)
+//
+// unmarshaller: the unmarshaller function to be used to unmarshal each model instance
+//
+// Usage Notes:
+// if 'result' is a:  | and propertyName is:     | then 'rawInput' should be:
+// -------------------+--------------------------+------------------------------------------------------------------
+// **Foo              | == ""                    | a map[string]json.RawMessage which directly
+//                    |                          | contains an instance of model Foo (i.e. each map entry represents
+//                    |                          | a property of Foo)
+//                    |                          |
+// **Foo              | != "" (e.g. "prop")      | a map[string]json.RawMessage and rawInput["prop"]
+//                    |                          | should contain an instance of Foo (i.e. it can itself be
+//                    |                          | unmarshalled into a map[string]json.RawMessage whose entries
+//                    |                          | represent the properties of Foo)
+// -------------------+--------------------------+------------------------------------------------------------------
+// *[]Foo             | == ""                    | a []json.RawMessage where each slice element contains
+//                    |                          | an instance of Foo (i.e. the json.RawMessage can be unmarshalled
+//                    |                          | into a Foo instance)
+//                    |                          |
+// *[]Foo             | != "" (e.g. "prop")      | a map[string]json.RawMessage and rawInput["prop"]
+//                    |                          | contains a []Foo (slice of Foo instances)
+// -------------------+--------------------------+------------------------------------------------------------------
+// *map[string]Foo    | == ""                    | a map[string]json.RawMessage which directly contains the
+//                    |                          | map[string]Foo (i.e. the value within each entry in 'rawInput'
+//                    |                          | contains an instance of Foo)
+//                    |                          |
+// *map[string]Foo    | != "" (e.g. "prop")      | a map[string]json.RawMessage and rawInput["prop"]
+//                    |                          | contains an instance of map[string]Foo 
+// -------------------+--------------------------+------------------------------------------------------------------
+// *map[string][]Foo  | == ""                    | a map[string]json.RawMessage which directly contains the
+//                    |                          | map[string][]Foo (i.e. the value within each entry in 'rawInput'
+//                    |                          | contains a []Foo)
+// *map[string][]Foo  | != "" (e.g. "prop")      | a map[string]json.RawMessage and rawInput["prop"]
+//                    |                          | contains an instance of map[string][]Foo
+// -------------------+--------------------------+------------------------------------------------------------------
+func UnmarshalModel(rawInput interface{}, propertyName string, result interface{}, unmarshaller ModelUnmarshaller) (err error) {
+	
+	// Reflect on 'result' to determine the type of unmarshal operation being requested.
+	rResultType := reflect.TypeOf(result).Elem()
+	
+	// Now delegate the work to the appropriate internal unmarshal function.
+	switch rResultType.Kind() {
+	case reflect.Ptr, reflect.Interface:
+		// Unmarshal a single instance of a model.
+		err = unmarshalModelInstance(rawInput, propertyName, result, unmarshaller)
+	case reflect.Slice:
+		// Unmarshal a slice of model instances.
+		err = unmarshalModelSlice(rawInput, propertyName, result, unmarshaller)
+	case reflect.Map:
+		// For a map, we need to look at the map entry type.
+		rEntryType := reflect.TypeOf(result).Elem().Elem()
+		switch rEntryType.Kind() {
+		case reflect.Struct, reflect.Interface:
+			// A map[string]<model>
+			err = unmarshalModelMap(rawInput, propertyName, result, unmarshaller)
+		case reflect.Slice:
+			// A map[string][]<model>
+			err = unmarshalModelSliceMap(rawInput, propertyName, result, unmarshaller)
+		default:
+			err = fmt.Errorf(errorUnsupportedMapEntryType, reflect.TypeOf(result).Elem().Elem().String())
+			return
+		}
+	default:
+		err = fmt.Errorf(errorUnsupportedResultType, reflect.TypeOf(result).Elem().String())
+		return
+	}
+	return
+}
+
+//
+// unmarshalModelInstance unmarshals 'rawInput' into an instance of a model.
+//
+// Parameters:
+//
+// rawInput: the unmarshal input source.
+//
+// propertyName: the name of the property within 'rawInput' that contains the instance of the model.
+// If 'propertyName' is specified as "" then 'rawInput' is assumed to contain the model instance directly.
+//
+// result: should be a ptr to a ptr to a model instance (e.g. **Foo for model type Foo).
+// A new instance of the model will be constructed and returned through the model pointer
+// that 'result' points to (i.e. it is legal for 'result' to point to a nil pointer).
+//
+// 'unmarshaller' is the generated unmarshal function used to unmarshal a single instance of the model.
+//
+func unmarshalModelInstance(rawInput interface{}, propertyName string, result interface{}, unmarshaller ModelUnmarshaller) (err error) {
+	var rawMap map[string]json.RawMessage
+	var ok bool
+
+	// rawInput should be a map[string]json.RawMessage
+	rawMap, ok = rawInput.(map[string]json.RawMessage)
+	if !ok {
+		err = fmt.Errorf(errorIncorrectInputType, "map[string]json.RawMessage", reflect.TypeOf(rawInput).String())
+		return
+	}
+
+	// If propertyName was specified, then retrieve that entry from 'rawInput' as our unmarshal input source.
+	// Otherwise, just use 'rawInput' directly.
+	if propertyName != "" {
+		rawMsg, foundIt := rawMap[propertyName]
+		if foundIt && rawMsg != nil {
+			// rawMsg should contain an instance of the model, so we need to unmarshal it into
+			// a map[string]RawMessage that we can pass to 'unmarshaller'.
+			rawMap = make(map[string]json.RawMessage)
+			err = json.Unmarshal(rawMsg, &rawMap)
+			if err != nil {
+				err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
+					reflect.TypeOf(result).Elem().Elem().String(), err.Error())
+				return
+			}
+		} else {
+			rawMap = nil
+		}
+	}
+
+	// Initialize our result to nil.
+	// Note: 'result' is a ptr to a ptr to a model struct.  
+	// We're using 'result' to set the model struct ptr to nil.
+	rResult := reflect.ValueOf(result).Elem()
+	rResult.Set(reflect.Zero(rResult.Type()))
+
+	// If there is an unmarshal input source, then unmarshal it.
+	if rawMap != nil {
+		err = unmarshaller(rawMap, result)
+		if err != nil {
+			err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
+				reflect.TypeOf(result).Elem().Elem().String(), err.Error())
+			return
+		}
+	}
+	return
+}
+
+//
+// unmarshalModelSlice unmarshals 'rawInput' into a slice of model instances.
+//
+// Parameters:
+//
+// rawInput: is the unmarshal input source, and should be one of the following:
+// 1. a map[string]json.RawMessage - in this case 'propertyName' should specify the name
+// of the property to retrieve from the map to obtain the []json.RawMessage containing the slice of model instances
+// to be unmarshalled.
+//
+// 2. a []json.RawMessage - in this case, 'propertyName' should be specified as "" to indicate that
+// the []json.RawMessage is available directly via the 'rawInput' parameter.
+//
+// propertyName: an optional name of a property to be retrieved from 'rawInput'.
+// If 'propertyName' is specified as a non-empty string, then 'rawInput' is assumed to be a map[string]RawMessage,
+// and the named property is retrieved to obtain the []json.RawMessage to be unmarshalled.
+// If 'propertyName' is specified as "", then 'rawInput' is assumed to be a []json.RawMessage and is used directly
+// as the unmarshal input source.
+//
+// result: this should be a pointer to a slice of the model type (e.g. *[]Foo for model type Foo).
+// This function will construct a new slice and return it through 'result'.
+//
+// 'unmarshaller' is the function used to unmarshal a single instance of the model.
+//
+func unmarshalModelSlice(rawInput interface{}, propertyName string, result interface{}, unmarshaller ModelUnmarshaller) (err error) {
+	var rawSlice []json.RawMessage
+	var foundIt bool
+
+	// If propertyName was specified, then retrieve that entry from 'rawInput' as our unmarshal input source.
+	// Otherwise, just use 'rawInput' directly.
+	if propertyName != "" {
+		rawMap, ok := rawInput.(map[string]json.RawMessage)
+		if !ok {
+			err = fmt.Errorf(errorIncorrectInputType, "map[string][]json.RawMessage", reflect.TypeOf(rawInput).String())
+			return
+		}
+
+		var rawMsg json.RawMessage
+		rawMsg, foundIt = rawMap[propertyName]
+		if foundIt && rawMsg != nil {
+			err = json.Unmarshal(rawMsg, &rawSlice)
+			if err != nil {
+				err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
+					reflect.TypeOf(result).Elem().String(), err.Error())
+				return
+			}
+		}
+	} else {
+		var ok bool
+		rawSlice, ok = rawInput.([]json.RawMessage)
+		if !ok {
+			err = fmt.Errorf(errorIncorrectInputType, "[]json.RawMessage", reflect.TypeOf(rawInput).String())
+			return
+		}
+		foundIt = true
+	}
+
+	// Get a reflective view of the result and initialize it.
+	var sliceSize int = 0
+	if (foundIt) {
+		sliceSize = len(rawSlice)
+	}
+	rResultSlice := reflect.ValueOf(result).Elem()
+	rResultSlice.Set(reflect.MakeSlice(reflect.TypeOf(result).Elem(), 0, sliceSize))
+
+	// If there is an unmarshal input source, then unmarshal it.
+	if foundIt && rawSlice != nil {
+		for _, rawMsg := range rawSlice {
+			// 'rawMsg' should contain an instance of the model - we need to unmarshal it into a map.
+			rawMap := make(map[string]json.RawMessage)
+			err = json.Unmarshal(rawMsg, &rawMap)
+			if err != nil {
+				err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
+					reflect.TypeOf(result).Elem().String(), err.Error())
+				return
+			}
+
+			// Reflectively construct a new ptr to a model instance to serve as the receiver of the unmarshal step.
+			rModelValue := reflect.New(reflect.PtrTo(reflect.TypeOf(result).Elem().Elem()))
+
+			// Invoke the model-specific unmarshaller.
+			err = unmarshaller(rawMap, rModelValue.Interface())
+			if err != nil {
+				err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
+					reflect.TypeOf(result).Elem().String(), err.Error())
+				return
+			}
+
+			// Add the model instance to the result slice (reflectively, of course :) ).
+			rResultSlice.Set(reflect.Append(rResultSlice, rModelValue.Elem().Elem()))
+		}
+	}
+	return
+}
+
+//
+// unmarshalModelMap unmarshals 'rawInput' into a map[string]<model>.
+//
+// Parameters:
+//
+// rawInput: the unmarshal input source in the form of a map[string]json.RawMessage.
+//
+// propertyName: an optional name of a property to be retrieved from 'rawInput'.
+// If 'propertyName' is specified as a non-empty string, then the specified property value is retrieved
+// from 'rawInput', and this value is assumed to contain the map[string]<model> to be unmarshalled.
+// If 'propertyName' is specified as "", then 'rawInput' will be used directly as the unmarshal input source.
+//
+// result: the unmarshal destination. This should be a pointer to map[string]<model> (e.g. *map[string]Foo for model type Foo).
+// If 'result' points to a nil map, this function will construct the map prior to adding entries to it.
+//
+// unmarshaller: the function used to unmarshal a single instance of the model.
+//
+func unmarshalModelMap(rawInput interface{}, propertyName string, result interface{}, unmarshaller ModelUnmarshaller) (err error) {
+	var rawMap map[string]json.RawMessage
+	var ok, foundIt bool
+
+	// rawInput should be a map[string]json.RawMessage.
+	rawMap, ok = rawInput.(map[string]json.RawMessage)
+	if !ok {
+		err = fmt.Errorf(errorIncorrectInputType, "map[string]json.RawMessage", reflect.TypeOf(rawInput).String())
+		return
+	}
+
+	// If propertyName was specified, then retrieve that entry from 'rawInput' as our unmarshal input source.
+	// Otherwise, just use 'rawInput' directly.
+	if propertyName != "" {
+		var rawMsg json.RawMessage
+		rawMsg, foundIt = rawMap[propertyName]
+		if foundIt && rawMsg != nil {
+			rawMap = make(map[string]json.RawMessage)
+			err = json.Unmarshal(rawMsg, &rawMap)
+			if err != nil {
+				err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
+					reflect.TypeOf(result).Elem().String(), err.Error())
+				return
+			}
+		}
+	} else {
+		foundIt = true
+	}
+
+	// Get a "reflective" view of the result map and initialize it.
+	rResultMap := reflect.ValueOf(result).Elem()
+	rResultMap.Set(reflect.MakeMap(reflect.TypeOf(result).Elem()))
+
+	// If there is an unmarshal input source, then unmarshal it.
+	if foundIt && rawMap != nil {
+		for k, v := range rawMap {
+			// Unmarshal the map entry's value (a json.RawMessage) into a map[string]RawMessage.
+			// The resulting map should contain an instance of the model.
+			modelInstanceMap := make(map[string]json.RawMessage)
+			err = json.Unmarshal(v, &modelInstanceMap)
+			if err != nil {
+				err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
+					reflect.TypeOf(result).Elem().String(), err.Error())
+				return
+			}
+
+			// Reflectively construct a new ptr to a model instance to serve as the receiver of the unmarshal step.
+			rModelValue := reflect.New(reflect.PtrTo(reflect.TypeOf(result).Elem().Elem()))
+
+			// Unmarshal the model instance contained in 'modelInstanceMap'.
+			err = unmarshaller(modelInstanceMap, rModelValue.Interface())
+			if err != nil {
+				err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
+					reflect.TypeOf(result).Elem().String(), err.Error())
+				return
+			}
+
+			// Now add the unmarshalled model instance to the result map (reflectively, of course :) ).
+			rResultMap.SetMapIndex(reflect.ValueOf(k), rModelValue.Elem().Elem())
+		}
+	}
+	return
+}
+
+//
+// unmarshalModelSliceMap unmarshals 'rawInput' into a map[string][]<model>.
+//
+// Parameters:
+//
+// rawInput: the unmarshal input source in the form of a map[string]json.RawMessage.
+//
+// propertyName: an optional name of a property to be retrieved from 'rawInput'.
+// If 'propertyName' is specified as a non-empty string, then the specified property value is retrieved
+// from 'rawInput', and this value is assumed to contain the map[string][]<model> to be unmarshalled.
+// If 'propertyName' is specified as "", then 'rawInput' will be used directly as the unmarshal input source.
+//
+// result: the unmarshal destination. This should be a pointer to a map[string][]<model>
+// (e.g. *map[string][]Foo for model type Foo).
+// If 'result' points to a nil map, this function will construct the map prior to adding entries to it.
+//
+// unmarshaller: the function used to unmarshal a single instance of the model.
+//
+func unmarshalModelSliceMap(rawInput interface{}, propertyName string, result interface{}, unmarshaller ModelUnmarshaller) (err error) {
+	var rawMap map[string]json.RawMessage
+	var ok, foundIt bool
+
+	// rawInput should be a map[string]json.RawMessage.
+	rawMap, ok = rawInput.(map[string]json.RawMessage)
+	if !ok {
+		err = fmt.Errorf(errorIncorrectInputType, "map[string]json.RawMessage", reflect.TypeOf(rawInput).String())
+		return
+	}
+
+	// If propertyName was specified, then retrieve that entry from 'rawInput' as our unmarshal input source.
+	// Otherwise, just use 'rawInput' directly.
+	if propertyName != "" {
+		var rawMsg json.RawMessage
+		rawMsg, foundIt = rawMap[propertyName]
+		if foundIt && rawMsg != nil {
+			rawMap = make(map[string]json.RawMessage)
+			err = json.Unmarshal(rawMsg, &rawMap)
+			if err != nil {
+				err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
+					reflect.TypeOf(result).Elem(), err.Error())
+				return
+			}
+		}
+	} else {
+		foundIt = true
+	}
+
+	// Get a "reflective" view of the result map and initialize it.
+	rResultMap := reflect.ValueOf(result).Elem()
+	rResultMap.Set(reflect.MakeMap(reflect.TypeOf(result).Elem()))
+
+	if foundIt && rawMap != nil {
+		for k, v := range rawMap {
+			// Each value in 'rawMap' should contain an instance of []<model>.
+			// We'll first unmarshal each value into a []jsonRawMessage, then unmarshal that
+			// into a []<model> using unmarshalModelSlice.
+			var rawSlice []json.RawMessage
+			err = json.Unmarshal(v, &rawSlice)
+			if err != nil {
+				err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
+					reflect.TypeOf(result).Elem().String(), err.Error())
+				return
+			}
+
+			// Construct a ptr to a slice of the correct type.
+			rSlicePtr := reflect.New(reflect.TypeOf(result).Elem().Elem())
+
+			// Unmarshal rawSlice into a []<model>.
+			err = unmarshalModelSlice(rawSlice, "", rSlicePtr.Interface(), unmarshaller)
+			if err != nil {
+				err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
+					reflect.TypeOf(result).Elem().String(), err.Error())
+				return
+			}
+
+			// Now add the unmarshalled []<model> to the result map (reflectively, of course :) ).
+			rResultMap.SetMapIndex(reflect.ValueOf(k), rSlicePtr.Elem())
+		}
+	}
+	return
+}
+
+// propInsert is a utility function used to optionally include the name of a property in an error message.
+func propInsert(propertyName string) string {
+	if propertyName != "" {
+		return fmt.Sprintf(errorPropertyInsert, propertyName)
+	}
+	return ""
+}

--- a/core/unmarshal_v2_models_test.go
+++ b/core/unmarshal_v2_models_test.go
@@ -41,8 +41,7 @@ func UnmarshalMyModel(m map[string]json.RawMessage, result interface{}) (err err
 	if err != nil {
 		return
 	}
-	objPtrPtr := result.(**MyModel)
-	*objPtrPtr = obj
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
 	return
 }
 
@@ -72,8 +71,7 @@ func UnmarshalModelStruct(m map[string]json.RawMessage, result interface{}) (err
 	if err != nil {
 		return
 	}
-	objPtrPtr := result.(**ModelStruct)
-	*objPtrPtr = obj
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
 	return
 }
 
@@ -124,13 +122,7 @@ func UnmarshalCar(m map[string]json.RawMessage, result interface{}) (err error) 
 	if err != nil {
 		return
 	}
-	if reflect.TypeOf(result).Elem().Kind() == reflect.Interface {
-		objIntfPtr := result.(*VehicleIntf)
-		*objIntfPtr = obj
-	} else if reflect.TypeOf(result).Elem().Kind() == reflect.Ptr {
-		objPtrPtr := result.(**Car)
-		*objPtrPtr = obj
-	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
 	return
 }
 
@@ -450,7 +442,7 @@ func TestUnmarshalModelAbstractSlice(t *testing.T) {
 	assert.Equal(t, "Car", *(myCar.VehicleType))
 	assert.Equal(t, "Ford", *(myCar.Make))
 	assert.Equal(t, "coupe", *(myCar.BodyStyle))
-	
+
 	// Unmarshal a slice of Cars directly.
 	var myCarSlice []Car
 	err = UnmarshalModel(rawSlice, "", &myCarSlice, UnmarshalCar)
@@ -459,7 +451,7 @@ func TestUnmarshalModelAbstractSlice(t *testing.T) {
 	assert.Equal(t, "Car", *(myCarSlice[0].VehicleType))
 	assert.Equal(t, "Ford", *(myCarSlice[0].Make))
 	assert.Equal(t, "coupe", *(myCarSlice[0].BodyStyle))
-	
+
 }
 
 func TestUnmarshalModelAbstractMap(t *testing.T) {
@@ -478,7 +470,7 @@ func TestUnmarshalModelAbstractMap(t *testing.T) {
 	assert.Equal(t, "Car", *(myCar.VehicleType))
 	assert.Equal(t, "Ford", *(myCar.Make))
 	assert.Equal(t, "coupe", *(myCar.BodyStyle))
-	
+
 	var myCarMap map[string]Car
 	err = UnmarshalModel(rawMap, "", &myCarMap, UnmarshalCar)
 	assert.Nil(t, err)
@@ -504,7 +496,7 @@ func TestUnmarshalModelAbstractSliceMap(t *testing.T) {
 	assert.Equal(t, "Car", *(myCar.VehicleType))
 	assert.Equal(t, "Ford", *(myCar.Make))
 	assert.Equal(t, "coupe", *(myCar.BodyStyle))
-	
+
 	var myCarSliceMap map[string][]Car
 	err = UnmarshalModel(rawMap, "", &myCarSliceMap, UnmarshalVehicle)
 	assert.Nil(t, err)

--- a/core/unmarshal_v2_models_test.go
+++ b/core/unmarshal_v2_models_test.go
@@ -1,0 +1,363 @@
+/**
+ * (C) Copyright IBM Corp. 2020.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+// This struct simulates a generated model.
+type MyModel struct {
+	// A string property.
+	Foo *string `json:"foo" validate:"required"`
+
+	// An integer property.
+	Bar *int64 `json:"bar" validate:"required"`
+}
+
+// This simulates a generated unmarshal function.
+func UnmarshalMyModel(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(MyModel)
+	err = UnmarshalPrimitive(m, "foo", &obj.Foo)
+	if err != nil {
+		return
+	}
+	err = UnmarshalPrimitive(m, "bar", &obj.Bar)
+	if err != nil {
+		return
+	}
+
+	objPtrPtr := result.(**MyModel)
+	*objPtrPtr = obj
+	return
+}
+
+// This struct simulates a generated model with properties that involve models.
+type ModelStruct struct {
+	Model         *MyModel             `json:"model" validate:"required"`
+	ModelSlice    []MyModel            `json:"model_slice" validate:"required"`
+	ModelMap      map[string]MyModel   `json:"model_map" validate:"required"`
+	ModelSliceMap map[string][]MyModel `json:"model_slice_map" validate:"required"`
+}
+
+// This simulates a generated unmarshal function.
+func UnmarshalModelStruct(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(ModelStruct)
+	err = UnmarshalModel(m, "model", &obj.Model, UnmarshalMyModel)
+	if err != nil {
+		return
+	}
+	err = UnmarshalModel(m, "model_slice", &obj.ModelSlice, UnmarshalMyModel)
+	if err != nil {
+		return
+	}
+	err = UnmarshalModel(m, "model_map", &obj.ModelMap, UnmarshalMyModel)
+	if err != nil {
+		return
+	}
+	err = UnmarshalModel(m, "model_slice_map", &obj.ModelSliceMap, UnmarshalMyModel)
+	if err != nil {
+		return
+	}
+	objPtrPtr := result.(**ModelStruct)
+	*objPtrPtr = obj
+	return
+}
+
+func TestUnmarshalModelInstanceNil(t *testing.T) {
+	jsonString := `{ 
+		"null_model": null,
+		"empty_model": { }
+	}`
+	rawMap := unmarshalMap(jsonString)
+
+	var err error
+	var myModel *MyModel
+
+	// Unmarshal a missing property.
+	myModel = nil
+	err = UnmarshalModel(rawMap, "missing_model", &myModel, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.Nil(t, myModel)
+
+	// Unmarshal an explicit null value.
+	myModel = nil
+	err = UnmarshalModel(rawMap, "null_model", &myModel, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.Nil(t, myModel)
+
+	// Unmarshal an "empty" model instance.
+	myModel = nil
+	err = UnmarshalModel(rawMap, "empty_model", &myModel, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.NotNil(t, myModel)
+	assert.Nil(t, myModel.Foo)
+	assert.Nil(t, myModel.Bar)
+}
+
+func TestUnmarshalModelInstance(t *testing.T) {
+	jsonString := `{ "foo": "string1", "bar": 44 }`
+
+	var err error
+	var myModel *MyModel
+
+	// Unmarshal an instance of the model.
+	rawMap := unmarshalMap(jsonString)
+	err = UnmarshalModel(rawMap, "", &myModel, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.NotNil(t, myModel)
+	assert.Equal(t, "string1", *(myModel.Foo))
+	assert.Equal(t, int64(44), *(myModel.Bar))
+
+}
+
+func TestUnmarshalModelSliceNil(t *testing.T) {
+	jsonString := `{ 
+		"null_slice": null,
+		"empty_slice": []
+	}`
+	rawMap := unmarshalMap(jsonString)
+
+	var err error
+	var mySlice []MyModel
+
+	// Unmarshal a missing property.
+	mySlice = nil
+	err = UnmarshalModel(rawMap, "missing_slice", &mySlice, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(mySlice))
+
+	// Unmarshal an explicit null value.
+	mySlice = nil
+	err = UnmarshalModel(rawMap, "null_slice", &mySlice, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(mySlice))
+
+	// Unmarshal an explicit null value.
+	mySlice = nil
+	err = UnmarshalModel(rawMap, "empty_slice", &mySlice, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(mySlice))
+}
+
+func TestUnmarshalModelSlice(t *testing.T) {
+	jsonString := `[ { "foo": "string1", "bar": 44 }, { "foo": "string2", "bar": 74 } ]`
+	var err error
+	var mySlice []MyModel
+
+	// Unmarshal a model slice.
+	rawSlice := unmarshalSlice(jsonString)
+	err = UnmarshalModel(rawSlice, "", &mySlice, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(mySlice))
+	assert.Equal(t, "string1", *(mySlice[0].Foo))
+	assert.Equal(t, int64(44), *(mySlice[0].Bar))
+	assert.Equal(t, "string2", *(mySlice[1].Foo))
+	assert.Equal(t, int64(74), *(mySlice[1].Bar))
+}
+
+func TestUnmarshalModelMapNil(t *testing.T) {
+	jsonString := `{ 
+		"null_map": null,
+		"empty_map": { }
+	}`
+	rawMap := unmarshalMap(jsonString)
+
+	var err error
+	var myMap map[string]MyModel
+
+	// Unmarshal a missing property.
+	myMap = nil
+	err = UnmarshalModel(rawMap, "missing_map", &myMap, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(myMap))
+
+	// Unmarshal an explicit null value.
+	myMap = nil
+	err = UnmarshalModel(rawMap, "null_map", &myMap, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.NotNil(t, myMap)
+	assert.Equal(t, 0, len(myMap))
+
+	// Unmarshal an empty map.
+	myMap = nil
+	err = UnmarshalModel(rawMap, "empty_map", &myMap, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.NotNil(t, myMap)
+	assert.Equal(t, 0, len(myMap))
+}
+
+func TestUnmarshalModelMap(t *testing.T) {
+	jsonString := `{
+		"model1": { "foo": "string1", "bar": 44 }, 
+		"model2": { "foo": "string2", "bar": 74 }
+	}`
+	var err error
+	var myMap map[string]MyModel
+
+	// Unmarshal a model map.
+	rawMap := unmarshalMap(jsonString)
+	err = UnmarshalModel(rawMap, "", &myMap, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(myMap))
+	assert.NotNil(t, myMap["model1"])
+	assert.NotNil(t, myMap["model2"])
+	
+	_, foundIt := myMap["bad_key"]
+	assert.False(t, foundIt)
+	
+	assert.Equal(t, "string1", *(myMap["model1"].Foo))
+	assert.Equal(t, int64(44), *(myMap["model1"].Bar))
+	assert.Equal(t, "string2", *(myMap["model2"].Foo))
+	assert.Equal(t, int64(74), *(myMap["model2"].Bar))
+}
+
+func TestUnmarshalModelSliceMapNil(t *testing.T) {
+	jsonString := `{ 
+		"null_prop": null, 
+		"empty_slice_map": { 
+			"empty_slice": [] 
+		},
+		"null_slice_map": { 
+			"null_slice": null
+		}
+	}`
+	rawMap := unmarshalMap(jsonString)
+
+	var err error
+	var mySliceMap map[string][]MyModel
+
+	// Unmarshal a missing property.
+	mySliceMap = nil
+	err = UnmarshalModel(rawMap, "missing_prop", &mySliceMap, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(mySliceMap))
+
+	// Unmarshal an explicit null value.
+	mySliceMap = nil
+	err = UnmarshalModel(rawMap, "null_prop", &mySliceMap, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(mySliceMap))
+
+	// Unmarshal a map with an empty slice.
+	mySliceMap = nil
+	err = UnmarshalModel(rawMap, "empty_slice_map", &mySliceMap, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(mySliceMap))
+	assert.NotNil(t, mySliceMap["empty_slice"])
+	assert.Equal(t, 0, len(mySliceMap["empty_slice"]))
+
+	// Unmarshal a map with an explicit null slice.
+	mySliceMap = nil
+	err = UnmarshalModel(rawMap, "null_slice_map", &mySliceMap, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(mySliceMap))
+	assert.NotNil(t, mySliceMap["null_slice"])
+	assert.Equal(t, 0, len(mySliceMap["null_slice"]))
+}
+
+func TestUnmarshalModelStruct(t *testing.T) {
+	m1 := `{ "foo": "string1", "bar": 44 }`
+	m2 := `{ "foo": "string2", "bar": 74 }`
+	m3 := `{ "foo": "string3", "bar": 33 }`
+	m4 := `{ "foo": "string4", "bar": 21 }`
+	jsonTemplate := `{
+		"model": %m1,
+		"model_slice": [ %m1, %m2 ],
+		"model_map": {
+			"model1": %m1,
+			"model2": %m2,
+			"model3": %m3,
+			"model4": %m4
+		},
+		"model_slice_map": {
+			"slice1": [ %m1, %m2, %m3 ],
+			"slice2": [ %m4 ]
+		}
+	}`
+	jsonString := strings.ReplaceAll(jsonTemplate, "%m1", m1)
+	jsonString = strings.ReplaceAll(jsonString, "%m2", m2)
+	jsonString = strings.ReplaceAll(jsonString, "%m3", m3)
+	jsonString = strings.ReplaceAll(jsonString, "%m4", m4)
+
+	var err error
+	var modelStruct *ModelStruct
+
+	rawMap := unmarshalMap(jsonString)
+	err = UnmarshalModel(rawMap, "", &modelStruct, UnmarshalModelStruct)
+	assert.Nil(t, err)
+	assert.NotNil(t, modelStruct)
+	assert.NotNil(t, modelStruct.Model)
+	assert.Equal(t, 2, len(modelStruct.ModelSlice))
+	assert.Equal(t, 4, len(modelStruct.ModelMap))
+	assert.Equal(t, 2, len(modelStruct.ModelSliceMap))
+
+	// Verify model instance.
+	assert.Equal(t, "string1", *(modelStruct.Model.Foo))
+	assert.Equal(t, int64(44), *(modelStruct.Model.Bar))
+	
+	// Verify model slice.
+	assert.Equal(t, "string1", *(modelStruct.ModelSlice[0].Foo))
+	assert.Equal(t, int64(44), *(modelStruct.ModelSlice[0].Bar))
+	assert.Equal(t, "string2", *(modelStruct.ModelSlice[1].Foo))
+	assert.Equal(t, int64(74), *(modelStruct.ModelSlice[1].Bar))
+	
+	// Verify model map.
+	assert.NotNil(t, modelStruct.ModelMap["model1"])
+	assert.NotNil(t, modelStruct.ModelMap["model2"])
+	assert.NotNil(t, modelStruct.ModelMap["model3"])
+	assert.NotNil(t, modelStruct.ModelMap["model4"])
+	_, foundIt := modelStruct.ModelMap["bad_key"]
+	assert.False(t, foundIt)
+	
+	assert.Equal(t, "string1", *(modelStruct.ModelMap["model1"].Foo))
+	assert.Equal(t, int64(44), *(modelStruct.ModelMap["model1"].Bar))
+	assert.Equal(t, "string2", *(modelStruct.ModelMap["model2"].Foo))
+	assert.Equal(t, int64(74), *(modelStruct.ModelMap["model2"].Bar))
+	assert.Equal(t, "string3", *(modelStruct.ModelMap["model3"].Foo))
+	assert.Equal(t, int64(33), *(modelStruct.ModelMap["model3"].Bar))
+	assert.Equal(t, "string4", *(modelStruct.ModelMap["model4"].Foo))
+	assert.Equal(t, int64(21), *(modelStruct.ModelMap["model4"].Bar))
+	
+	// Verify model slice map.
+	assert.NotNil(t, modelStruct.ModelSliceMap["slice1"])
+	assert.Equal(t, 3, len(modelStruct.ModelSliceMap["slice1"]))
+	assert.NotNil(t, modelStruct.ModelSliceMap["slice2"])
+	assert.Equal(t, 1, len(modelStruct.ModelSliceMap["slice2"]))
+	
+	assert.Equal(t, "string1", *(modelStruct.ModelSliceMap["slice1"][0].Foo))
+	assert.Equal(t, int64(44), *(modelStruct.ModelSliceMap["slice1"][0].Bar))
+	assert.Equal(t, "string2", *(modelStruct.ModelSliceMap["slice1"][1].Foo))
+	assert.Equal(t, int64(74), *(modelStruct.ModelSliceMap["slice1"][1].Bar))
+	assert.Equal(t, "string3", *(modelStruct.ModelSliceMap["slice1"][2].Foo))
+	assert.Equal(t, int64(33), *(modelStruct.ModelSliceMap["slice1"][2].Bar))
+	
+	assert.Equal(t, "string4", *(modelStruct.ModelSliceMap["slice2"][0].Foo))
+	assert.Equal(t, int64(21), *(modelStruct.ModelSliceMap["slice2"][0].Bar))
+}
+
+// Utility function that unmarshals a JSON string into
+func unmarshalSlice(jsonString string) (result []json.RawMessage) {
+	err := json.Unmarshal([]byte(jsonString), &result)
+	if err != nil {
+		panic(err)
+	}
+	return
+}

--- a/core/unmarshal_v2_models_test.go
+++ b/core/unmarshal_v2_models_test.go
@@ -18,21 +18,19 @@ package core
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/stretchr/testify/assert"
+	"reflect"
 	"strings"
 	"testing"
 )
 
-// This struct simulates a generated model.
+// This simulates a generated model with its unmarshal function.
 type MyModel struct {
-	// A string property.
 	Foo *string `json:"foo" validate:"required"`
-
-	// An integer property.
-	Bar *int64 `json:"bar" validate:"required"`
+	Bar *int64  `json:"bar" validate:"required"`
 }
 
-// This simulates a generated unmarshal function.
 func UnmarshalMyModel(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(MyModel)
 	err = UnmarshalPrimitive(m, "foo", &obj.Foo)
@@ -43,13 +41,12 @@ func UnmarshalMyModel(m map[string]json.RawMessage, result interface{}) (err err
 	if err != nil {
 		return
 	}
-
 	objPtrPtr := result.(**MyModel)
 	*objPtrPtr = obj
 	return
 }
 
-// This struct simulates a generated model with properties that involve models.
+// This simulates a generated model with properties that involve models, along with its unmarshal function.
 type ModelStruct struct {
 	Model         *MyModel             `json:"model" validate:"required"`
 	ModelSlice    []MyModel            `json:"model_slice" validate:"required"`
@@ -57,7 +54,6 @@ type ModelStruct struct {
 	ModelSliceMap map[string][]MyModel `json:"model_slice_map" validate:"required"`
 }
 
-// This simulates a generated unmarshal function.
 func UnmarshalModelStruct(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(ModelStruct)
 	err = UnmarshalModel(m, "model", &obj.Model, UnmarshalMyModel)
@@ -78,6 +74,63 @@ func UnmarshalModelStruct(m map[string]json.RawMessage, result interface{}) (err
 	}
 	objPtrPtr := result.(**ModelStruct)
 	*objPtrPtr = obj
+	return
+}
+
+// This simulates a "parent" struct (interface) with a discriminator along with one "substruct" and their unmarshal functions.
+// The Vehicle struct is not defined here because the linter informed me that it wasn't being used :)
+type VehicleIntf interface {
+	isaVehicle() bool
+}
+
+func UnmarshalVehicle(m map[string]json.RawMessage, result interface{}) (err error) {
+	var discValue string
+	err = UnmarshalPrimitive(m, "vehicle_type", &discValue)
+	if err != nil {
+		return
+	}
+	if discValue == "" {
+		err = fmt.Errorf("discriminator property 'vehicle_type' not found in JSON object")
+		return
+	}
+	if discValue == "Car" {
+		err = UnmarshalCar(m, result)
+	} else {
+		err = fmt.Errorf("unrecognized value for discriminator property 'vehicle_type': %s", discValue)
+	}
+	return
+}
+
+type Car struct {
+	VehicleType *string `json:"vehicle_type" validate:"required"`
+	Make        *string `json:"make,omitempty"`
+	BodyStyle   *string `json:"body_style,omitempty"`
+}
+
+func (*Car) isaVehicle() bool {
+	return true
+}
+func UnmarshalCar(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(Car)
+	err = UnmarshalPrimitive(m, "vehicle_type", &obj.VehicleType)
+	if err != nil {
+		return
+	}
+	err = UnmarshalPrimitive(m, "make", &obj.Make)
+	if err != nil {
+		return
+	}
+	err = UnmarshalPrimitive(m, "body_style", &obj.BodyStyle)
+	if err != nil {
+		return
+	}
+	if reflect.TypeOf(result).Elem().Kind() == reflect.Interface {
+		objIntfPtr := result.(*VehicleIntf)
+		*objIntfPtr = obj
+	} else if reflect.TypeOf(result).Elem().Kind() == reflect.Ptr {
+		objPtrPtr := result.(**Car)
+		*objPtrPtr = obj
+	}
 	return
 }
 
@@ -125,7 +178,6 @@ func TestUnmarshalModelInstance(t *testing.T) {
 	assert.NotNil(t, myModel)
 	assert.Equal(t, "string1", *(myModel.Foo))
 	assert.Equal(t, int64(44), *(myModel.Bar))
-
 }
 
 func TestUnmarshalModelSliceNil(t *testing.T) {
@@ -219,10 +271,10 @@ func TestUnmarshalModelMap(t *testing.T) {
 	assert.Equal(t, 2, len(myMap))
 	assert.NotNil(t, myMap["model1"])
 	assert.NotNil(t, myMap["model2"])
-	
+
 	_, foundIt := myMap["bad_key"]
 	assert.False(t, foundIt)
-	
+
 	assert.Equal(t, "string1", *(myMap["model1"].Foo))
 	assert.Equal(t, int64(44), *(myMap["model1"].Bar))
 	assert.Equal(t, "string2", *(myMap["model2"].Foo))
@@ -312,13 +364,13 @@ func TestUnmarshalModelStruct(t *testing.T) {
 	// Verify model instance.
 	assert.Equal(t, "string1", *(modelStruct.Model.Foo))
 	assert.Equal(t, int64(44), *(modelStruct.Model.Bar))
-	
+
 	// Verify model slice.
 	assert.Equal(t, "string1", *(modelStruct.ModelSlice[0].Foo))
 	assert.Equal(t, int64(44), *(modelStruct.ModelSlice[0].Bar))
 	assert.Equal(t, "string2", *(modelStruct.ModelSlice[1].Foo))
 	assert.Equal(t, int64(74), *(modelStruct.ModelSlice[1].Bar))
-	
+
 	// Verify model map.
 	assert.NotNil(t, modelStruct.ModelMap["model1"])
 	assert.NotNil(t, modelStruct.ModelMap["model2"])
@@ -326,7 +378,7 @@ func TestUnmarshalModelStruct(t *testing.T) {
 	assert.NotNil(t, modelStruct.ModelMap["model4"])
 	_, foundIt := modelStruct.ModelMap["bad_key"]
 	assert.False(t, foundIt)
-	
+
 	assert.Equal(t, "string1", *(modelStruct.ModelMap["model1"].Foo))
 	assert.Equal(t, int64(44), *(modelStruct.ModelMap["model1"].Bar))
 	assert.Equal(t, "string2", *(modelStruct.ModelMap["model2"].Foo))
@@ -335,22 +387,294 @@ func TestUnmarshalModelStruct(t *testing.T) {
 	assert.Equal(t, int64(33), *(modelStruct.ModelMap["model3"].Bar))
 	assert.Equal(t, "string4", *(modelStruct.ModelMap["model4"].Foo))
 	assert.Equal(t, int64(21), *(modelStruct.ModelMap["model4"].Bar))
-	
+
 	// Verify model slice map.
 	assert.NotNil(t, modelStruct.ModelSliceMap["slice1"])
 	assert.Equal(t, 3, len(modelStruct.ModelSliceMap["slice1"]))
 	assert.NotNil(t, modelStruct.ModelSliceMap["slice2"])
 	assert.Equal(t, 1, len(modelStruct.ModelSliceMap["slice2"]))
-	
+
 	assert.Equal(t, "string1", *(modelStruct.ModelSliceMap["slice1"][0].Foo))
 	assert.Equal(t, int64(44), *(modelStruct.ModelSliceMap["slice1"][0].Bar))
 	assert.Equal(t, "string2", *(modelStruct.ModelSliceMap["slice1"][1].Foo))
 	assert.Equal(t, int64(74), *(modelStruct.ModelSliceMap["slice1"][1].Bar))
 	assert.Equal(t, "string3", *(modelStruct.ModelSliceMap["slice1"][2].Foo))
 	assert.Equal(t, int64(33), *(modelStruct.ModelSliceMap["slice1"][2].Bar))
-	
+
 	assert.Equal(t, "string4", *(modelStruct.ModelSliceMap["slice2"][0].Foo))
 	assert.Equal(t, int64(21), *(modelStruct.ModelSliceMap["slice2"][0].Bar))
+}
+
+func TestUnmarshalModelAbstractInstance(t *testing.T) {
+	jsonString := `{ "vehicle_type": "Car", "make": "Ford", "body_style": "coupe"}`
+
+	var err error
+	var myVehicle VehicleIntf
+
+	// Unmarshal an instance of the parent (should end up with a Car).
+	rawMap := unmarshalMap(jsonString)
+	err = UnmarshalModel(rawMap, "", &myVehicle, UnmarshalVehicle)
+	assert.Nil(t, err)
+	assert.NotNil(t, myVehicle)
+	myCar, ok := myVehicle.(*Car)
+	assert.True(t, ok)
+	assert.NotNil(t, myCar)
+	assert.Equal(t, "Car", *(myCar.VehicleType))
+	assert.Equal(t, "Ford", *(myCar.Make))
+	assert.Equal(t, "coupe", *(myCar.BodyStyle))
+
+	// Unmarshal an instance of the substruct directly.
+	myCar = nil
+	err = UnmarshalModel(rawMap, "", &myCar, UnmarshalCar)
+	assert.Nil(t, err)
+	assert.NotNil(t, myCar)
+	assert.Equal(t, "Car", *(myCar.VehicleType))
+	assert.Equal(t, "Ford", *(myCar.Make))
+	assert.Equal(t, "coupe", *(myCar.BodyStyle))
+}
+
+func TestUnmarshalModelAbstractSlice(t *testing.T) {
+	jsonString := `[{ "vehicle_type": "Car", "make": "Ford", "body_style": "coupe"}]`
+
+	var err error
+	var myVehicleSlice []VehicleIntf
+
+	// Unmarshal a slice of Vehicles.
+	rawSlice := unmarshalSlice(jsonString)
+	err = UnmarshalModel(rawSlice, "", &myVehicleSlice, UnmarshalVehicle)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(myVehicleSlice))
+	myCar, ok := myVehicleSlice[0].(*Car)
+	assert.True(t, ok)
+	assert.NotNil(t, myCar)
+	assert.Equal(t, "Car", *(myCar.VehicleType))
+	assert.Equal(t, "Ford", *(myCar.Make))
+	assert.Equal(t, "coupe", *(myCar.BodyStyle))
+	
+	// Unmarshal a slice of Cars directly.
+	var myCarSlice []Car
+	err = UnmarshalModel(rawSlice, "", &myCarSlice, UnmarshalCar)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(myCarSlice))
+	assert.Equal(t, "Car", *(myCarSlice[0].VehicleType))
+	assert.Equal(t, "Ford", *(myCarSlice[0].Make))
+	assert.Equal(t, "coupe", *(myCarSlice[0].BodyStyle))
+	
+}
+
+func TestUnmarshalModelAbstractMap(t *testing.T) {
+	jsonString := `{ "car1": { "vehicle_type": "Car", "make": "Ford", "body_style": "coupe"} }`
+
+	var err error
+	var myVehicleMap map[string]VehicleIntf
+
+	rawMap := unmarshalMap(jsonString)
+	err = UnmarshalModel(rawMap, "", &myVehicleMap, UnmarshalVehicle)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(myVehicleMap))
+	myCar, ok := myVehicleMap["car1"].(*Car)
+	assert.True(t, ok)
+	assert.NotNil(t, myCar)
+	assert.Equal(t, "Car", *(myCar.VehicleType))
+	assert.Equal(t, "Ford", *(myCar.Make))
+	assert.Equal(t, "coupe", *(myCar.BodyStyle))
+	
+	var myCarMap map[string]Car
+	err = UnmarshalModel(rawMap, "", &myCarMap, UnmarshalCar)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(myCarMap))
+	assert.Equal(t, "Car", *(myCarMap["car1"].VehicleType))
+	assert.Equal(t, "Ford", *(myCarMap["car1"].Make))
+	assert.Equal(t, "coupe", *(myCarMap["car1"].BodyStyle))
+}
+
+func TestUnmarshalModelAbstractSliceMap(t *testing.T) {
+	jsonString := `{ "carSlice1": [ { "vehicle_type": "Car", "make": "Ford", "body_style": "coupe"} ] }`
+
+	var err error
+	var myVehicleSliceMap map[string][]VehicleIntf
+
+	rawMap := unmarshalMap(jsonString)
+	err = UnmarshalModel(rawMap, "", &myVehicleSliceMap, UnmarshalVehicle)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(myVehicleSliceMap))
+	myCar, ok := myVehicleSliceMap["carSlice1"][0].(*Car)
+	assert.True(t, ok)
+	assert.NotNil(t, myCar)
+	assert.Equal(t, "Car", *(myCar.VehicleType))
+	assert.Equal(t, "Ford", *(myCar.Make))
+	assert.Equal(t, "coupe", *(myCar.BodyStyle))
+	
+	var myCarSliceMap map[string][]Car
+	err = UnmarshalModel(rawMap, "", &myCarSliceMap, UnmarshalVehicle)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(myCarSliceMap))
+	assert.Equal(t, 1, len(myCarSliceMap["carSlice1"]))
+	assert.Equal(t, "Car", *(myCarSliceMap["carSlice1"][0].VehicleType))
+	assert.Equal(t, "Ford", *(myCarSliceMap["carSlice1"][0].Make))
+	assert.Equal(t, "coupe", *(myCarSliceMap["carSlice1"][0].BodyStyle))
+}
+
+func TestUnmarshalModelErrors(t *testing.T) {
+	modelStruct := new(ModelStruct)
+	var rawSlice []json.RawMessage
+	var rawMap map[string]json.RawMessage
+	var err error
+
+	// Supply a slice when a map is expected.
+	rawSlice = unmarshalSlice(`[ { "prop": "value" } ]`)
+	err = UnmarshalModel(rawSlice, "", &modelStruct.Model, UnmarshalMyModel)
+	assert.NotNil(t, err)
+	assert.Nil(t, modelStruct.Model)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling core.MyModel"))
+	t.Logf("[01] Expected error: %s\n", err.Error())
+
+	// Supply an incorrect map.
+	rawMap = unmarshalMap(`{ "prop": "value"}`)
+	err = UnmarshalModel(rawMap, "prop", &modelStruct.Model, UnmarshalMyModel)
+	assert.NotNil(t, err)
+	assert.Nil(t, modelStruct.ModelSlice)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'prop' as core.MyModel"))
+	t.Logf("[02] Expected error: %s\n", err.Error())
+
+	// Supply a map with an incorrect MyModel instance.
+	rawMap = unmarshalMap(`{ "foo": "string", "bar": "string" }`)
+	err = UnmarshalModel(rawMap, "", &modelStruct.Model, UnmarshalMyModel)
+	assert.NotNil(t, err)
+	assert.Nil(t, modelStruct.ModelSlice)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling core.MyModel"))
+	t.Logf("[03] Expected error: %s\n", err.Error())
+
+	// Supply a map when a slice is expected.
+	rawMap = unmarshalMap(`{ "prop": "value"}`)
+	err = UnmarshalModel(rawMap, "", &modelStruct.ModelSlice, UnmarshalMyModel)
+	assert.NotNil(t, err)
+	assert.Nil(t, modelStruct.ModelSlice)
+	assert.True(t, strings.Contains(err.Error(), "expected 'rawInput' to be a []json.RawMessage"))
+	t.Logf("[04] Expected error: %s\n", err.Error())
+
+	// Supply an incorrect map.
+	rawMap = unmarshalMap(`{ "prop": "value"}`)
+	err = UnmarshalModel(rawMap, "prop", &modelStruct.ModelSlice, UnmarshalMyModel)
+	assert.NotNil(t, err)
+	assert.Nil(t, modelStruct.ModelSlice)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'prop' as []core.MyModel"))
+	t.Logf("[05] Expected error: %s\n", err.Error())
+
+	// Supply a map with an incorrect MyModel instance.
+	rawMap = unmarshalMap(`{ "prop": [ {"foo": 38, "bar": 38} ] }`)
+	err = UnmarshalModel(rawMap, "prop", &modelStruct.ModelSlice, UnmarshalMyModel)
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, len(modelStruct.ModelSlice))
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'prop' as []core.MyModel"))
+	t.Logf("[06] Expected error: %s\n", err.Error())
+
+	// Supply a slice when a map is expected.
+	rawSlice = unmarshalSlice(`[ { "prop": "value" } ]`)
+	err = UnmarshalModel(rawSlice, "prop", &modelStruct.ModelSlice, UnmarshalMyModel)
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, len(modelStruct.ModelSlice))
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'prop' as []core.MyModel"))
+	t.Logf("[07] Expected error: %s\n", err.Error())
+
+	// Supply a slice when a map is expected.
+	rawSlice = unmarshalSlice(`[ { "prop": "value" } ]`)
+	err = UnmarshalModel(rawSlice, "", &modelStruct.ModelMap, UnmarshalMyModel)
+	assert.NotNil(t, err)
+	assert.Nil(t, modelStruct.ModelMap)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling map[string]core.MyModel"))
+	t.Logf("[08] Expected error: %s\n", err.Error())
+
+	// Supply an incorrect map.
+	rawMap = unmarshalMap(`{ "prop": "value"}`)
+	err = UnmarshalModel(rawMap, "prop", &modelStruct.ModelMap, UnmarshalMyModel)
+	assert.NotNil(t, err)
+	assert.Nil(t, modelStruct.ModelMap)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'prop' as map[string]core.MyModel"))
+	t.Logf("[09] Expected error: %s\n", err.Error())
+
+	// Supply a map with an incorrect MyModel instance.
+	rawMap = unmarshalMap(`{ "foo1": {"foo": 38, "bar": 38} }`)
+	err = UnmarshalModel(rawMap, "", &modelStruct.ModelMap, UnmarshalMyModel)
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, len(modelStruct.ModelMap))
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling map[string]core.MyModel"))
+	t.Logf("[10] Expected error: %s\n", err.Error())
+
+	// Supply a slice when a map is expected.
+	rawSlice = unmarshalSlice(`[ { "prop": "value" } ]`)
+	err = UnmarshalModel(rawSlice, "", &modelStruct.ModelSliceMap, UnmarshalMyModel)
+	assert.NotNil(t, err)
+	assert.Nil(t, modelStruct.ModelSliceMap)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling map[string][]core.MyModel"))
+	t.Logf("[11] Expected error: %s\n", err.Error())
+
+	// Supply an incorrect map.
+	rawMap = unmarshalMap(`{ "prop": "value"}`)
+	err = UnmarshalModel(rawMap, "prop", &modelStruct.ModelSliceMap, UnmarshalMyModel)
+	assert.NotNil(t, err)
+	assert.Nil(t, modelStruct.ModelSliceMap)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'prop' as map[string][]core.MyModel"))
+	t.Logf("[12] Expected error: %s\n", err.Error())
+}
+
+func TestUnmarshalModelAbstractErrors(t *testing.T) {
+	var err error
+	var myVehicle VehicleIntf
+	var mySlice []VehicleIntf
+	var myMap map[string]VehicleIntf
+	var mySliceMap map[string][]VehicleIntf
+	var rawMap map[string]json.RawMessage
+	var rawSlice []json.RawMessage
+
+	// Not a valid discriminator value.
+	rawMap = unmarshalMap(`{ "vehicle_type": "EV", "make": "Ford", "body_style": "Mach-E"}`)
+	err = UnmarshalModel(rawMap, "", &myVehicle, UnmarshalVehicle)
+	assert.NotNil(t, err)
+	assert.Nil(t, myVehicle)
+	t.Logf("[01] Expected error: %s\n", err.Error())
+
+	// Not a valid discriminator value type.
+	rawMap = unmarshalMap(`{ "vehicle_type": 44, "make": "Ford", "body_style": "Mach-E"}`)
+	err = UnmarshalModel(rawMap, "", &myVehicle, UnmarshalVehicle)
+	assert.NotNil(t, err)
+	assert.Nil(t, myVehicle)
+	t.Logf("[02] Expected error: %s\n", err.Error())
+
+	// Not a valid model instance
+	rawMap = unmarshalMap(`{ "vehicle_type": "Car", "make": "Ford", "body_style": 44 }`)
+	err = UnmarshalModel(rawMap, "", &myVehicle, UnmarshalVehicle)
+	assert.NotNil(t, err)
+	assert.Nil(t, myVehicle)
+	t.Logf("[03] Expected error: %s\n", err.Error())
+
+	// Not a valid model slice.
+	rawSlice = unmarshalSlice(`[{ "vehicle_type": "Car", "make": "Ford", "body_style": 44 }]`)
+	err = UnmarshalModel(rawSlice, "", &mySlice, UnmarshalVehicle)
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, len(mySlice))
+	t.Logf("[04] Expected error: %s\n", err.Error())
+
+	// Not a valid model slice.
+	rawSlice = unmarshalSlice(`[{ "vehicle_type": "EV", "make": "Ford", "body_style": 44 }]`)
+	err = UnmarshalModel(rawSlice, "", &mySlice, UnmarshalVehicle)
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, len(mySlice))
+	t.Logf("[05] Expected error: %s\n", err.Error())
+
+	// Not a valid model map.
+	rawMap = unmarshalMap(`{ "vehicle1": { "vehicle_type": "EV", "make": "Ford", "body_style": 44 } }`)
+	err = UnmarshalModel(rawMap, "", &myMap, UnmarshalVehicle)
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, len(myMap))
+	t.Logf("[06] Expected error: %s\n", err.Error())
+
+	// Not a valid model slice map.
+	rawMap = unmarshalMap(`{ "vehicleSlice1": [ { "vehicle_type": "EV", "make": "Ford", "body_style": 44 } ] }`)
+	err = UnmarshalModel(rawMap, "", &mySliceMap, UnmarshalVehicle)
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, len(myMap))
+	t.Logf("[07] Expected error: %s\n", err.Error())
 }
 
 // Utility function that unmarshals a JSON string into

--- a/core/unmarshal_v2_primitives_test.go
+++ b/core/unmarshal_v2_primitives_test.go
@@ -73,6 +73,11 @@ func TestUnmarshalPrimitiveString(t *testing.T) {
 	assert.NotNil(t, model.Prop)
 	assert.Equal(t, s1, *(model.Prop))
 
+	var aString string
+	err = UnmarshalPrimitive(rawMap, "prop", &aString)
+	assert.Nil(t, err)
+	assert.Equal(t, s1, aString)
+
 	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
 	assert.Nil(t, err)
 	assert.NotNil(t, model.PropSlice)
@@ -196,6 +201,11 @@ func TestUnmarshalPrimitiveBool(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, model.Prop)
 	assert.Equal(t, b1, *(model.Prop))
+
+	var aBool bool
+	err = UnmarshalPrimitive(rawMap, "prop", &aBool)
+	assert.Nil(t, err)
+	assert.Equal(t, b1, aBool)
 
 	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
 	assert.Nil(t, err)
@@ -322,6 +332,11 @@ func TestUnmarshalPrimitiveByteArray(t *testing.T) {
 	assert.NotNil(t, model.Prop)
 	assert.Equal(t, s1, string(*(model.Prop)))
 
+	var aBA []byte
+	err = UnmarshalPrimitive(rawMap, "prop", &aBA)
+	assert.Nil(t, err)
+	assert.Equal(t, s1, string(aBA))
+
 	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
 	assert.Nil(t, err)
 	assert.NotNil(t, model.PropSlice)
@@ -444,6 +459,11 @@ func TestUnmarshalPrimitiveInt64(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, model.Prop)
 	assert.Equal(t, n1, *(model.Prop))
+
+	var anInt int64
+	err = UnmarshalPrimitive(rawMap, "prop", &anInt)
+	assert.Nil(t, err)
+	assert.Equal(t, n1, anInt)
 
 	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
 	assert.Nil(t, err)
@@ -568,6 +588,11 @@ func TestUnmarshalPrimitiveFloat32(t *testing.T) {
 	assert.NotNil(t, model.Prop)
 	assert.Equal(t, n1, *(model.Prop))
 
+	var aFloat float32
+	err = UnmarshalPrimitive(rawMap, "prop", &aFloat)
+	assert.Nil(t, err)
+	assert.Equal(t, n1, aFloat)
+
 	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
 	assert.Nil(t, err)
 	assert.NotNil(t, model.PropSlice)
@@ -691,6 +716,11 @@ func TestUnmarshalPrimitiveFloat64(t *testing.T) {
 	assert.NotNil(t, model.Prop)
 	assert.Equal(t, n1, *(model.Prop))
 
+	var aFloat float64
+	err = UnmarshalPrimitive(rawMap, "prop", &aFloat)
+	assert.Nil(t, err)
+	assert.Equal(t, n1, aFloat)
+
 	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
 	assert.Nil(t, err)
 	assert.NotNil(t, model.PropSlice)
@@ -786,6 +816,9 @@ func TestUnmarshalPrimitiveDate(t *testing.T) {
 		"prop_slice_map_slice": [{"key1": ["%d1"]}, {"key2": ["%d2", "%d3", "%d4"]} ],
 		
 		"bad_type":  true,
+		"bad_date1": "",
+		"bad_date2": "10-27-2004",
+		"bad_date3": "she/he was a psycho",
 		"not_a_slice": false,
 		"bad_slice_type": [38, 26],
 		"null_prop": null
@@ -813,6 +846,11 @@ func TestUnmarshalPrimitiveDate(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, model.Prop)
 	assert.Equal(t, d1, model.Prop.String())
+
+	var aDate strfmt.Date
+	err = UnmarshalPrimitive(rawMap, "prop", &aDate)
+	assert.Nil(t, err)
+	assert.Equal(t, d1, aDate.String())
 
 	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
 	assert.Nil(t, err)
@@ -888,6 +926,21 @@ func TestUnmarshalPrimitiveDate(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_slice_type'"))
 	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "bad_date1", &model.Prop)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_date1'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "bad_date2", &model.Prop)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_date2'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "bad_date3", &model.Prop)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_date3'"))
+	t.Logf("Expected error: %s\n", err.Error())
 }
 
 func TestUnmarshalPrimitiveDateTime(t *testing.T) {
@@ -909,6 +962,9 @@ func TestUnmarshalPrimitiveDateTime(t *testing.T) {
 		"prop_slice_map_slice": [{"key1": ["%d1"]}, {"key2": ["%d2", "%d3", "%d4"]} ],
 		
 		"bad_type":  true,
+		"bad_date1": "",
+		"bad_date2": "10-27-2004T00:00:00Z",
+		"bad_date3": "1970-01-01 18:30:00Z",
 		"not_a_slice": false,
 		"bad_slice_type": [38, 26],
 		"null_prop": null
@@ -941,6 +997,11 @@ func TestUnmarshalPrimitiveDateTime(t *testing.T) {
 	assert.NotNil(t, model.Prop)
 	assert.Equal(t, d1, model.Prop.String())
 
+	var aDateTime strfmt.DateTime
+	err = UnmarshalPrimitive(rawMap, "prop", &aDateTime)
+	assert.Nil(t, err)
+	assert.Equal(t, d1, aDateTime.String())
+
 	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
 	assert.Nil(t, err)
 	assert.NotNil(t, model.PropSlice)
@@ -1015,6 +1076,23 @@ func TestUnmarshalPrimitiveDateTime(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_slice_type'"))
 	t.Logf("Expected error: %s\n", err.Error())
+
+	// It turns out that the standard strfmt.DateTime unmarshal code will actually successfully unmarshal ""
+	// as a DateTime value (epoch time - 1970-01-01T00:00:00.000Z).
+	err = UnmarshalPrimitive(rawMap, "bad_date1", &model.Prop)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.Prop)
+	assert.Equal(t, "1970-01-01T00:00:00.000Z", model.Prop.String())
+
+	err = UnmarshalPrimitive(rawMap, "bad_date2", &model.Prop)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_date2'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "bad_date3", &model.Prop)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_date3'"))
+	t.Logf("Expected error: %s\n", err.Error())
 }
 
 func TestUnmarshalPrimitiveUUID(t *testing.T) {
@@ -1035,6 +1113,8 @@ func TestUnmarshalPrimitiveUUID(t *testing.T) {
 		"prop_map_slice": [{"key1": "%u1"}, {"key2": "%u2"}],
 		"prop_slice_map_slice": [{"key1": ["%u1"]}, {"key2": ["%u2", "%u3", "%u4"]} ],
 		
+		"empty_uuid": "",
+		"bad_uuid": "not a real uuid",
 		"bad_type":  true,
 		"not_a_slice": false,
 		"bad_slice_type": [38, 26],
@@ -1063,6 +1143,11 @@ func TestUnmarshalPrimitiveUUID(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, model.Prop)
 	assert.Equal(t, u1, model.Prop.String())
+
+	var aUuid strfmt.UUID
+	err = UnmarshalPrimitive(rawMap, "prop", &aUuid)
+	assert.Nil(t, err)
+	assert.Equal(t, u1, aUuid.String())
 
 	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
 	assert.Nil(t, err)
@@ -1138,6 +1223,14 @@ func TestUnmarshalPrimitiveUUID(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_slice_type'"))
 	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "empty_uuid", &model.Prop)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.Prop)
+
+	err = UnmarshalPrimitive(rawMap, "bad_uuid", &model.Prop)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.Prop)
 }
 
 func TestUnmarshalPrimitiveAny(t *testing.T) {
@@ -1158,9 +1251,9 @@ func TestUnmarshalPrimitiveAny(t *testing.T) {
 		"prop_map_slice": [{"key1": %f1}, {"key2": %f1}],
 		"prop_slice_map_slice": [{"key1": ["%s1"]}, {"key2": [%n1, %n1, %n2]} ],
 		
-		"bad_type":  true,
+		"ok_type":  true,
 		"not_a_slice": false,
-		"bad_slice_type": [38, 26],
+		"ok_slice_type": [38, 26],
 		"null_prop": null
 	}`
 
@@ -1255,7 +1348,7 @@ func TestUnmarshalPrimitiveAny(t *testing.T) {
 
 	// Negative tests
 	model.Prop = nil
-	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
+	err = UnmarshalPrimitive(rawMap, "ok_type", &model.Prop)
 	assert.Nil(t, err)
 	assert.NotNil(t, model.Prop)
 
@@ -1265,7 +1358,7 @@ func TestUnmarshalPrimitiveAny(t *testing.T) {
 	t.Logf("Expected error: %s\n", err.Error())
 
 	model.PropSlice = nil
-	err = UnmarshalPrimitive(rawMap, "bad_slice_type", &model.PropSlice)
+	err = UnmarshalPrimitive(rawMap, "ok_slice_type", &model.PropSlice)
 	assert.Nil(t, err)
 	assert.NotNil(t, model.PropSlice)
 }

--- a/core/unmarshal_v2_primitives_test.go
+++ b/core/unmarshal_v2_primitives_test.go
@@ -1,0 +1,1386 @@
+/**
+ * (C) Copyright IBM Corp. 2020.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestUnmarshalPrimitiveString(t *testing.T) {
+	type MyModel struct {
+		Prop              *string
+		PropSlice         []string
+		PropMap           map[string]string
+		PropSliceMap      map[string][]string
+		PropMapSlice      []map[string]string
+		PropSliceMapSlice []map[string][]string
+	}
+
+	jsonTemplate := `{
+		"prop": "%s1",
+		"prop_slice": ["%s1", "%s2"],
+		"prop_map": { "key1": "%s1", "key2": "%s2" },
+		"prop_slice_map": { "key1": ["%s1", "%s2"], "key2": ["%s3", "%s4"] },
+		"prop_map_slice": [{"key1": "%s1"}, {"key2": "%s2"}],
+		"prop_slice_map_slice": [{"key1": ["%s1"]}, {"key2": ["%s2", "%s3", "%s4"]} ],
+		
+		"bad_type":  true,
+		"not_a_slice": false,
+		"bad_slice_type": [38, 26],
+		"null_prop": null
+	}`
+
+	s1 := "value1"
+	s2 := "value2"
+	s3 := "value3"
+	s4 := "value4"
+
+	jsonString := strings.ReplaceAll(jsonTemplate, "%s1", s1)
+	jsonString = strings.ReplaceAll(jsonString, "%s2", s2)
+	jsonString = strings.ReplaceAll(jsonString, "%s3", s3)
+	jsonString = strings.ReplaceAll(jsonString, "%s4", s4)
+
+	rawMap := unmarshalMap(jsonString)
+	assert.NotNil(t, rawMap)
+
+	model := new(MyModel)
+
+	var err error
+
+	// Positive tests
+	err = UnmarshalPrimitive(rawMap, "prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.Prop)
+	assert.Equal(t, s1, *(model.Prop))
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, s1, model.PropSlice[0])
+	assert.Equal(t, s2, model.PropSlice[1])
+
+	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMap)
+	assert.Equal(t, s1, model.PropMap["key1"])
+	assert.Equal(t, s2, model.PropMap["key2"])
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMap)
+	assert.Equal(t, s1, model.PropSliceMap["key1"][0])
+	assert.Equal(t, s2, model.PropSliceMap["key1"][1])
+	assert.Equal(t, s3, model.PropSliceMap["key2"][0])
+	assert.Equal(t, s4, model.PropSliceMap["key2"][1])
+
+	err = UnmarshalPrimitive(rawMap, "prop_map_slice", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMapSlice)
+	assert.Equal(t, s1, model.PropMapSlice[0]["key1"])
+	assert.Equal(t, s2, model.PropMapSlice[1]["key2"])
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map_slice", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMapSlice)
+	assert.Equal(t, s1, model.PropSliceMapSlice[0]["key1"][0])
+	assert.Equal(t, s2, model.PropSliceMapSlice[1]["key2"][0])
+	assert.Equal(t, s3, model.PropSliceMapSlice[1]["key2"][1])
+	assert.Equal(t, s4, model.PropSliceMapSlice[1]["key2"][2])
+
+	// Tests involving a JSON null value
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.Nil(t, model.Prop)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSlice)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMapSlice)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMapSlice)
+
+	// Negative tests
+	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_type'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "not_a_slice", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'not_a_slice'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "bad_slice_type", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_slice_type'"))
+	t.Logf("Expected error: %s\n", err.Error())
+	
+	err = UnmarshalPrimitive(rawMap, "", &model.Prop)
+	assert.NotNil(t, err)
+	assert.Equal(t, "the 'propertyName' parameter is required", err.Error())
+	t.Logf("Expected error: %s\n", err.Error())
+}
+
+func TestUnmarshalPrimitiveBool(t *testing.T) {
+	type MyModel struct {
+		Prop              *bool
+		PropSlice         []bool
+		PropMap           map[string]bool
+		PropSliceMap      map[string][]bool
+		PropMapSlice      []map[string]bool
+		PropSliceMapSlice []map[string][]bool
+	}
+
+	jsonTemplate := `{
+		"prop": %b1,
+		"prop_slice": [%b1, %b2],
+		"prop_map": { "key1": %b1, "key2": %b2 },
+		"prop_slice_map": { "key1": [%b2, %b1], "key2": [%b1, %b2] },
+		"prop_map_slice": [{"key1": %b1}, {"key2": %b2}],
+		"prop_slice_map_slice": [{"key1": [%b1]}, {"key2": [%b2, %b2, %b1]} ],
+		
+		"bad_type":  "string",
+		"not_a_slice": 38,
+		"bad_slice_type": [38, 26],
+		"null_prop": null
+	}`
+
+	b1 := true
+	b2 := false
+
+	jsonString := strings.ReplaceAll(jsonTemplate, "%b1", "true")
+	jsonString = strings.ReplaceAll(jsonString, "%b2", "false")
+
+	rawMap := unmarshalMap(jsonString)
+	assert.NotNil(t, rawMap)
+
+	model := new(MyModel)
+
+	var err error
+
+	// Positive tests
+	err = UnmarshalPrimitive(rawMap, "prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.Prop)
+	assert.Equal(t, b1, *(model.Prop))
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, b1, model.PropSlice[0])
+	assert.Equal(t, b2, model.PropSlice[1])
+
+	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMap)
+	assert.Equal(t, b1, model.PropMap["key1"])
+	assert.Equal(t, b2, model.PropMap["key2"])
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMap)
+	assert.Equal(t, b2, model.PropSliceMap["key1"][0])
+	assert.Equal(t, b1, model.PropSliceMap["key1"][1])
+	assert.Equal(t, b1, model.PropSliceMap["key2"][0])
+	assert.Equal(t, b2, model.PropSliceMap["key2"][1])
+
+	err = UnmarshalPrimitive(rawMap, "prop_map_slice", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMapSlice)
+	assert.Equal(t, b1, model.PropMapSlice[0]["key1"])
+	assert.Equal(t, b2, model.PropMapSlice[1]["key2"])
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map_slice", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMapSlice)
+	assert.Equal(t, b1, model.PropSliceMapSlice[0]["key1"][0])
+	assert.Equal(t, b2, model.PropSliceMapSlice[1]["key2"][0])
+	assert.Equal(t, b2, model.PropSliceMapSlice[1]["key2"][1])
+	assert.Equal(t, b1, model.PropSliceMapSlice[1]["key2"][2])
+
+	// Tests involving a JSON null value
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.Nil(t, model.Prop)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSlice)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMapSlice)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMapSlice)
+
+	// Negative tests
+	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_type'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "not_a_slice", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'not_a_slice'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "bad_slice_type", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_slice_type'"))
+	t.Logf("Expected error: %s\n", err.Error())
+}
+
+func TestUnmarshalPrimitiveByteArray(t *testing.T) {
+	type MyModel struct {
+		Prop              *[]byte
+		PropSlice         [][]byte
+		PropMap           map[string][]byte
+		PropSliceMap      map[string][][]byte
+		PropMapSlice      []map[string][]byte
+		PropSliceMapSlice []map[string][][]byte
+	}
+
+	s1 := "You're gonna need a bigger boat."
+	s2 := "I'm gonna make him an offer he can't refuse."
+	encodedString1 := base64.StdEncoding.EncodeToString([]byte(s1))
+	encodedString2 := base64.StdEncoding.EncodeToString([]byte(s2))
+	assert.NotNil(t, encodedString1)
+	assert.NotNil(t, encodedString2)
+
+	jsonStringTemplate := `{
+		"prop": "%s1",
+		"prop_slice": ["%s1", "%s2"],
+		"prop_map": { "key1": "%s2", "key2": "%s1" },
+		"prop_slice_map": { "key1": ["%s1", "%s2"], "key2": ["%s2", "%s1"] },
+		"prop_map_slice": [{"key1": "%s2"}, {"key2": "%s1"}],
+		"prop_slice_map_slice": [{"key1": ["%s1"]}, {"key2": ["%s2", "%s2", "%s1"]} ],
+		
+		"bad_type":  true,
+		"not_a_slice": false,
+		"bad_slice_type": [38, 26],
+		"null_prop": null
+	}`
+
+	jsonString := strings.ReplaceAll(jsonStringTemplate, "%s1", encodedString1)
+	jsonString = strings.ReplaceAll(jsonString, "%s2", encodedString2)
+
+	// t.Logf("json string: %s\n", jsonString)
+
+	rawMap := unmarshalMap(jsonString)
+	assert.NotNil(t, rawMap)
+
+	model := new(MyModel)
+
+	var err error
+
+	// Positive tests
+	err = UnmarshalPrimitive(rawMap, "prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.Prop)
+	assert.Equal(t, s1, string(*(model.Prop)))
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, s1, string(model.PropSlice[0]))
+	assert.Equal(t, s2, string(model.PropSlice[1]))
+
+	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMap)
+	assert.Equal(t, s2, string(model.PropMap["key1"]))
+	assert.Equal(t, s1, string(model.PropMap["key2"]))
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMap)
+	assert.Equal(t, s1, string(model.PropSliceMap["key1"][0]))
+	assert.Equal(t, s2, string(model.PropSliceMap["key1"][1]))
+	assert.Equal(t, s2, string(model.PropSliceMap["key2"][0]))
+	assert.Equal(t, s1, string(model.PropSliceMap["key2"][1]))
+
+	err = UnmarshalPrimitive(rawMap, "prop_map_slice", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMapSlice)
+	assert.Equal(t, s2, string(model.PropMapSlice[0]["key1"]))
+	assert.Equal(t, s1, string(model.PropMapSlice[1]["key2"]))
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map_slice", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMapSlice)
+	assert.Equal(t, s1, string(model.PropSliceMapSlice[0]["key1"][0]))
+	assert.Equal(t, s2, string(model.PropSliceMapSlice[1]["key2"][0]))
+	assert.Equal(t, s2, string(model.PropSliceMapSlice[1]["key2"][1]))
+	assert.Equal(t, s1, string(model.PropSliceMapSlice[1]["key2"][2]))
+
+	// Tests involving a JSON null value
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.Nil(t, model.Prop)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSlice)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMapSlice)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMapSlice)
+
+	// Negative tests
+	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_type'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "not_a_slice", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'not_a_slice'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "bad_slice_type", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_slice_type'"))
+	t.Logf("Expected error: %s\n", err.Error())
+}
+
+func TestUnmarshalPrimitiveInt64(t *testing.T) {
+	type MyModel struct {
+		Prop              *int64
+		PropSlice         []int64
+		PropMap           map[string]int64
+		PropSliceMap      map[string][]int64
+		PropMapSlice      []map[string]int64
+		PropSliceMapSlice []map[string][]int64
+	}
+
+	jsonTemplate := `{
+		"prop": %n1,
+		"prop_slice": [%n1, %n2],
+		"prop_map": { "key1": %n1, "key2": %n2 },
+		"prop_slice_map": { "key1": [%n1, %n2], "key2": [%n3, %n4] },
+		"prop_map_slice": [{"key1": %n1}, {"key2": %n2}],
+		"prop_slice_map_slice": [{"key1": [%n1]}, {"key2": [%n2, %n3, %n4]} ],
+		
+		"bad_type":  true,
+		"not_a_slice": false,
+		"bad_slice_type": [true, false],
+		"null_prop": null
+	}`
+
+	n1 := int64(44)
+	n2 := int64(74)
+	n3 := int64(27)
+	n4 := int64(50)
+
+	jsonString := strings.ReplaceAll(jsonTemplate, "%n1", fmt.Sprintf("%d", n1))
+	jsonString = strings.ReplaceAll(jsonString, "%n2", fmt.Sprintf("%d", n2))
+	jsonString = strings.ReplaceAll(jsonString, "%n3", fmt.Sprintf("%d", n3))
+	jsonString = strings.ReplaceAll(jsonString, "%n4", fmt.Sprintf("%d", n4))
+
+	rawMap := unmarshalMap(jsonString)
+	assert.NotNil(t, rawMap)
+
+	model := new(MyModel)
+
+	var err error
+
+	// Positive tests
+	err = UnmarshalPrimitive(rawMap, "prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.Prop)
+	assert.Equal(t, n1, *(model.Prop))
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, n1, model.PropSlice[0])
+	assert.Equal(t, n2, model.PropSlice[1])
+
+	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMap)
+	assert.Equal(t, n1, model.PropMap["key1"])
+	assert.Equal(t, n2, model.PropMap["key2"])
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMap)
+	assert.Equal(t, n1, model.PropSliceMap["key1"][0])
+	assert.Equal(t, n2, model.PropSliceMap["key1"][1])
+	assert.Equal(t, n3, model.PropSliceMap["key2"][0])
+	assert.Equal(t, n4, model.PropSliceMap["key2"][1])
+
+	err = UnmarshalPrimitive(rawMap, "prop_map_slice", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMapSlice)
+	assert.Equal(t, n1, model.PropMapSlice[0]["key1"])
+	assert.Equal(t, n2, model.PropMapSlice[1]["key2"])
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map_slice", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMapSlice)
+	assert.Equal(t, n1, model.PropSliceMapSlice[0]["key1"][0])
+	assert.Equal(t, n2, model.PropSliceMapSlice[1]["key2"][0])
+	assert.Equal(t, n3, model.PropSliceMapSlice[1]["key2"][1])
+	assert.Equal(t, n4, model.PropSliceMapSlice[1]["key2"][2])
+
+	// Tests involving a JSON null value
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.Nil(t, model.Prop)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSlice)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMapSlice)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMapSlice)
+
+	// Negative tests
+	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_type'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "not_a_slice", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'not_a_slice'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "bad_slice_type", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_slice_type'"))
+	t.Logf("Expected error: %s\n", err.Error())
+}
+
+func TestUnmarshalPrimitiveFloat32(t *testing.T) {
+	type MyModel struct {
+		Prop              *float32
+		PropSlice         []float32
+		PropMap           map[string]float32
+		PropSliceMap      map[string][]float32
+		PropMapSlice      []map[string]float32
+		PropSliceMapSlice []map[string][]float32
+	}
+
+	jsonTemplate := `{
+		"prop": %n1,
+		"prop_slice": [%n1, %n2],
+		"prop_map": { "key1": %n1, "key2": %n2 },
+		"prop_slice_map": { "key1": [%n1, %n2], "key2": [%n3, %n4] },
+		"prop_map_slice": [{"key1": %n1}, {"key2": %n2}],
+		"prop_slice_map_slice": [{"key1": [%n1]}, {"key2": [%n2, %n3, %n4]} ],
+		
+		"bad_type":  true,
+		"not_a_slice": false,
+		"bad_slice_type": [true, false],
+		"null_prop": null
+	}`
+
+	n1 := float32(44.5)
+	n2 := float32(74.8)
+	n3 := float32(27.1)
+	n4 := float32(50.9)
+
+	jsonString := strings.ReplaceAll(jsonTemplate, "%n1", fmt.Sprintf("%f", n1))
+	jsonString = strings.ReplaceAll(jsonString, "%n2", fmt.Sprintf("%f", n2))
+	jsonString = strings.ReplaceAll(jsonString, "%n3", fmt.Sprintf("%f", n3))
+	jsonString = strings.ReplaceAll(jsonString, "%n4", fmt.Sprintf("%f", n4))
+
+	rawMap := unmarshalMap(jsonString)
+	assert.NotNil(t, rawMap)
+
+	model := new(MyModel)
+
+	var err error
+
+	// Positive tests
+	err = UnmarshalPrimitive(rawMap, "prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.Prop)
+	assert.Equal(t, n1, *(model.Prop))
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, n1, model.PropSlice[0])
+	assert.Equal(t, n2, model.PropSlice[1])
+
+	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMap)
+	assert.Equal(t, n1, model.PropMap["key1"])
+	assert.Equal(t, n2, model.PropMap["key2"])
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMap)
+	assert.Equal(t, n1, model.PropSliceMap["key1"][0])
+	assert.Equal(t, n2, model.PropSliceMap["key1"][1])
+	assert.Equal(t, n3, model.PropSliceMap["key2"][0])
+	assert.Equal(t, n4, model.PropSliceMap["key2"][1])
+
+	err = UnmarshalPrimitive(rawMap, "prop_map_slice", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMapSlice)
+	assert.Equal(t, n1, model.PropMapSlice[0]["key1"])
+	assert.Equal(t, n2, model.PropMapSlice[1]["key2"])
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map_slice", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMapSlice)
+	assert.Equal(t, n1, model.PropSliceMapSlice[0]["key1"][0])
+	assert.Equal(t, n2, model.PropSliceMapSlice[1]["key2"][0])
+	assert.Equal(t, n3, model.PropSliceMapSlice[1]["key2"][1])
+	assert.Equal(t, n4, model.PropSliceMapSlice[1]["key2"][2])
+
+	// Tests involving a JSON null value
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.Nil(t, model.Prop)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSlice)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMapSlice)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMapSlice)
+
+	// Negative tests
+	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_type'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "not_a_slice", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'not_a_slice'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "bad_slice_type", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_slice_type'"))
+	t.Logf("Expected error: %s\n", err.Error())
+}
+
+func TestUnmarshalPrimitiveFloat64(t *testing.T) {
+	type MyModel struct {
+		Prop              *float64
+		PropSlice         []float64
+		PropMap           map[string]float64
+		PropSliceMap      map[string][]float64
+		PropMapSlice      []map[string]float64
+		PropSliceMapSlice []map[string][]float64
+	}
+
+	jsonTemplate := `{
+		"prop": %n1,
+		"prop_slice": [%n1, %n2],
+		"prop_map": { "key1": %n1, "key2": %n2 },
+		"prop_slice_map": { "key1": [%n1, %n2], "key2": [%n3, %n4] },
+		"prop_map_slice": [{"key1": %n1}, {"key2": %n2}],
+		"prop_slice_map_slice": [{"key1": [%n1]}, {"key2": [%n2, %n3, %n4]} ],
+		
+		"bad_type":  true,
+		"not_a_slice": false,
+		"bad_slice_type": [true, false],
+		"null_prop": null
+	}`
+
+	n1 := float64(44.5)
+	n2 := float64(74.8)
+	n3 := float64(27.1)
+	n4 := float64(50.9)
+
+	jsonString := strings.ReplaceAll(jsonTemplate, "%n1", fmt.Sprintf("%f", n1))
+	jsonString = strings.ReplaceAll(jsonString, "%n2", fmt.Sprintf("%f", n2))
+	jsonString = strings.ReplaceAll(jsonString, "%n3", fmt.Sprintf("%f", n3))
+	jsonString = strings.ReplaceAll(jsonString, "%n4", fmt.Sprintf("%f", n4))
+
+	rawMap := unmarshalMap(jsonString)
+	assert.NotNil(t, rawMap)
+
+	model := new(MyModel)
+
+	var err error
+
+	// Positive tests
+	err = UnmarshalPrimitive(rawMap, "prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.Prop)
+	assert.Equal(t, n1, *(model.Prop))
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, n1, model.PropSlice[0])
+	assert.Equal(t, n2, model.PropSlice[1])
+
+	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMap)
+	assert.Equal(t, n1, model.PropMap["key1"])
+	assert.Equal(t, n2, model.PropMap["key2"])
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMap)
+	assert.Equal(t, n1, model.PropSliceMap["key1"][0])
+	assert.Equal(t, n2, model.PropSliceMap["key1"][1])
+	assert.Equal(t, n3, model.PropSliceMap["key2"][0])
+	assert.Equal(t, n4, model.PropSliceMap["key2"][1])
+
+	err = UnmarshalPrimitive(rawMap, "prop_map_slice", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMapSlice)
+	assert.Equal(t, n1, model.PropMapSlice[0]["key1"])
+	assert.Equal(t, n2, model.PropMapSlice[1]["key2"])
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map_slice", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMapSlice)
+	assert.Equal(t, n1, model.PropSliceMapSlice[0]["key1"][0])
+	assert.Equal(t, n2, model.PropSliceMapSlice[1]["key2"][0])
+	assert.Equal(t, n3, model.PropSliceMapSlice[1]["key2"][1])
+	assert.Equal(t, n4, model.PropSliceMapSlice[1]["key2"][2])
+
+	// Tests involving a JSON null value
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.Nil(t, model.Prop)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSlice)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMapSlice)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMapSlice)
+
+	// Negative tests
+	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_type'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "not_a_slice", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'not_a_slice'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "bad_slice_type", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_slice_type'"))
+	t.Logf("Expected error: %s\n", err.Error())
+}
+
+func TestUnmarshalPrimitiveDate(t *testing.T) {
+	type MyModel struct {
+		Prop              *strfmt.Date
+		PropSlice         []strfmt.Date
+		PropMap           map[string]strfmt.Date
+		PropSliceMap      map[string][]strfmt.Date
+		PropMapSlice      []map[string]strfmt.Date
+		PropSliceMapSlice []map[string][]strfmt.Date
+	}
+
+	jsonTemplate := `{
+		"prop": "%d1",
+		"prop_slice": ["%d1", "%d2"],
+		"prop_map": { "key1": "%d1", "key2": "%d2" },
+		"prop_slice_map": { "key1": ["%d1", "%d2"], "key2": ["%d3", "%d4"] },
+		"prop_map_slice": [{"key1": "%d1"}, {"key2": "%d2"}],
+		"prop_slice_map_slice": [{"key1": ["%d1"]}, {"key2": ["%d2", "%d3", "%d4"]} ],
+		
+		"bad_type":  true,
+		"not_a_slice": false,
+		"bad_slice_type": [38, 26],
+		"null_prop": null
+	}`
+
+	d1 := "2004-10-27"
+	d2 := "2007-10-28"
+	d3 := "2013-10-30"
+	d4 := "2018-10-28"
+
+	jsonString := strings.ReplaceAll(jsonTemplate, "%d1", d1)
+	jsonString = strings.ReplaceAll(jsonString, "%d2", d2)
+	jsonString = strings.ReplaceAll(jsonString, "%d3", d3)
+	jsonString = strings.ReplaceAll(jsonString, "%d4", d4)
+
+	rawMap := unmarshalMap(jsonString)
+	assert.NotNil(t, rawMap)
+
+	model := new(MyModel)
+
+	var err error
+
+	// Positive tests
+	err = UnmarshalPrimitive(rawMap, "prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.Prop)
+	assert.Equal(t, d1, model.Prop.String())
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, d1, model.PropSlice[0].String())
+	assert.Equal(t, d2, model.PropSlice[1].String())
+
+	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMap)
+	assert.Equal(t, d1, model.PropMap["key1"].String())
+	assert.Equal(t, d2, model.PropMap["key2"].String())
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMap)
+	assert.Equal(t, d1, model.PropSliceMap["key1"][0].String())
+	assert.Equal(t, d2, model.PropSliceMap["key1"][1].String())
+	assert.Equal(t, d3, model.PropSliceMap["key2"][0].String())
+	assert.Equal(t, d4, model.PropSliceMap["key2"][1].String())
+
+	err = UnmarshalPrimitive(rawMap, "prop_map_slice", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMapSlice)
+	assert.Equal(t, d1, model.PropMapSlice[0]["key1"].String())
+	assert.Equal(t, d2, model.PropMapSlice[1]["key2"].String())
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map_slice", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMapSlice)
+	assert.Equal(t, d1, model.PropSliceMapSlice[0]["key1"][0].String())
+	assert.Equal(t, d2, model.PropSliceMapSlice[1]["key2"][0].String())
+	assert.Equal(t, d3, model.PropSliceMapSlice[1]["key2"][1].String())
+	assert.Equal(t, d4, model.PropSliceMapSlice[1]["key2"][2].String())
+
+	// Tests involving a JSON null value
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.Nil(t, model.Prop)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSlice)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMapSlice)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMapSlice)
+
+	// Negative tests
+	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_type'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "not_a_slice", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'not_a_slice'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "bad_slice_type", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_slice_type'"))
+	t.Logf("Expected error: %s\n", err.Error())
+}
+
+func TestUnmarshalPrimitiveDateTime(t *testing.T) {
+	type MyModel struct {
+		Prop              *strfmt.DateTime
+		PropSlice         []strfmt.DateTime
+		PropMap           map[string]strfmt.DateTime
+		PropSliceMap      map[string][]strfmt.DateTime
+		PropMapSlice      []map[string]strfmt.DateTime
+		PropSliceMapSlice []map[string][]strfmt.DateTime
+	}
+
+	jsonTemplate := `{
+		"prop": "%d1",
+		"prop_slice": ["%d1", "%d2"],
+		"prop_map": { "key1": "%d1", "key2": "%d2" },
+		"prop_slice_map": { "key1": ["%d1", "%d2"], "key2": ["%d3", "%d4"] },
+		"prop_map_slice": [{"key1": "%d1"}, {"key2": "%d2"}],
+		"prop_slice_map_slice": [{"key1": ["%d1"]}, {"key2": ["%d2", "%d3", "%d4"]} ],
+		
+		"bad_type":  true,
+		"not_a_slice": false,
+		"bad_slice_type": [38, 26],
+		"null_prop": null
+	}`
+
+	d1 := "1969-07-20T20:17:00"
+	d2 := "1963-11-22T18:30:00Z"
+	d3 := "2001-09-11T13:46:00.333Z"
+	d4 := "2011-05-02T20:00:00.011Z"
+
+	jsonString := strings.ReplaceAll(jsonTemplate, "%d1", d1)
+	jsonString = strings.ReplaceAll(jsonString, "%d2", d2)
+	jsonString = strings.ReplaceAll(jsonString, "%d3", d3)
+	jsonString = strings.ReplaceAll(jsonString, "%d4", d4)
+	
+	// Expected values need to include ms
+	d1 = "1969-07-20T20:17:00.000Z"
+	d2 = "1963-11-22T18:30:00.000Z"
+
+	rawMap := unmarshalMap(jsonString)
+	assert.NotNil(t, rawMap)
+
+	model := new(MyModel)
+
+	var err error
+
+	// Positive tests
+	err = UnmarshalPrimitive(rawMap, "prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.Prop)
+	assert.Equal(t, d1, model.Prop.String())
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, d1, model.PropSlice[0].String())
+	assert.Equal(t, d2, model.PropSlice[1].String())
+
+	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMap)
+	assert.Equal(t, d1, model.PropMap["key1"].String())
+	assert.Equal(t, d2, model.PropMap["key2"].String())
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMap)
+	assert.Equal(t, d1, model.PropSliceMap["key1"][0].String())
+	assert.Equal(t, d2, model.PropSliceMap["key1"][1].String())
+	assert.Equal(t, d3, model.PropSliceMap["key2"][0].String())
+	assert.Equal(t, d4, model.PropSliceMap["key2"][1].String())
+
+	err = UnmarshalPrimitive(rawMap, "prop_map_slice", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMapSlice)
+	assert.Equal(t, d1, model.PropMapSlice[0]["key1"].String())
+	assert.Equal(t, d2, model.PropMapSlice[1]["key2"].String())
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map_slice", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMapSlice)
+	assert.Equal(t, d1, model.PropSliceMapSlice[0]["key1"][0].String())
+	assert.Equal(t, d2, model.PropSliceMapSlice[1]["key2"][0].String())
+	assert.Equal(t, d3, model.PropSliceMapSlice[1]["key2"][1].String())
+	assert.Equal(t, d4, model.PropSliceMapSlice[1]["key2"][2].String())
+
+	// Tests involving a JSON null value
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.Nil(t, model.Prop)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSlice)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMapSlice)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMapSlice)
+
+	// Negative tests
+	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_type'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "not_a_slice", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'not_a_slice'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "bad_slice_type", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_slice_type'"))
+	t.Logf("Expected error: %s\n", err.Error())
+}
+
+func TestUnmarshalPrimitiveUUID(t *testing.T) {
+	type MyModel struct {
+		Prop              *strfmt.UUID
+		PropSlice         []strfmt.UUID
+		PropMap           map[string]strfmt.UUID
+		PropSliceMap      map[string][]strfmt.UUID
+		PropMapSlice      []map[string]strfmt.UUID
+		PropSliceMapSlice []map[string][]strfmt.UUID
+	}
+
+	jsonTemplate := `{
+		"prop": "%u1",
+		"prop_slice": ["%u1", "%u2"],
+		"prop_map": { "key1": "%u1", "key2": "%u2" },
+		"prop_slice_map": { "key1": ["%u1", "%u2"], "key2": ["%u3", "%u4"] },
+		"prop_map_slice": [{"key1": "%u1"}, {"key2": "%u2"}],
+		"prop_slice_map_slice": [{"key1": ["%u1"]}, {"key2": ["%u2", "%u3", "%u4"]} ],
+		
+		"bad_type":  true,
+		"not_a_slice": false,
+		"bad_slice_type": [38, 26],
+		"null_prop": null
+	}`
+
+	u1 := "63769e9f-94e6-4ab6-8c68-dd33f69fb535"
+	u2 := "e43db1b8-673a-4033-bf18-ded07172700f"
+	u3 := "7c5a5c8c-bba1-453b-8e65-c56ffd0aab07"
+	u4 := "43bde04f-5581-448e-bd51-50f554c41ac4"
+
+	jsonString := strings.ReplaceAll(jsonTemplate, "%u1", u1)
+	jsonString = strings.ReplaceAll(jsonString, "%u2", u2)
+	jsonString = strings.ReplaceAll(jsonString, "%u3", u3)
+	jsonString = strings.ReplaceAll(jsonString, "%u4", u4)
+
+	rawMap := unmarshalMap(jsonString)
+	assert.NotNil(t, rawMap)
+
+	model := new(MyModel)
+
+	var err error
+
+	// Positive tests
+	err = UnmarshalPrimitive(rawMap, "prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.Prop)
+	assert.Equal(t, u1, model.Prop.String())
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, u1, model.PropSlice[0].String())
+	assert.Equal(t, u2, model.PropSlice[1].String())
+
+	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMap)
+	assert.Equal(t, u1, model.PropMap["key1"].String())
+	assert.Equal(t, u2, model.PropMap["key2"].String())
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMap)
+	assert.Equal(t, u1, model.PropSliceMap["key1"][0].String())
+	assert.Equal(t, u2, model.PropSliceMap["key1"][1].String())
+	assert.Equal(t, u3, model.PropSliceMap["key2"][0].String())
+	assert.Equal(t, u4, model.PropSliceMap["key2"][1].String())
+
+	err = UnmarshalPrimitive(rawMap, "prop_map_slice", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMapSlice)
+	assert.Equal(t, u1, model.PropMapSlice[0]["key1"].String())
+	assert.Equal(t, u2, model.PropMapSlice[1]["key2"].String())
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map_slice", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMapSlice)
+	assert.Equal(t, u1, model.PropSliceMapSlice[0]["key1"][0].String())
+	assert.Equal(t, u2, model.PropSliceMapSlice[1]["key2"][0].String())
+	assert.Equal(t, u3, model.PropSliceMapSlice[1]["key2"][1].String())
+	assert.Equal(t, u4, model.PropSliceMapSlice[1]["key2"][2].String())
+
+	// Tests involving a JSON null value
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.Nil(t, model.Prop)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSlice)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMapSlice)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMapSlice)
+
+	// Negative tests
+	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_type'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "not_a_slice", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'not_a_slice'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "bad_slice_type", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_slice_type'"))
+	t.Logf("Expected error: %s\n", err.Error())
+}
+
+func TestUnmarshalPrimitiveAny(t *testing.T) {
+	type MyModel struct {
+		Prop              interface{}
+		PropSlice         []interface{}
+		PropMap           map[string]interface{}
+		PropSliceMap      map[string][]interface{}
+		PropMapSlice      []map[string]interface{}
+		PropSliceMapSlice []map[string][]interface{}
+	}
+
+	jsonTemplate := `{
+		"prop": "%s1",
+		"prop_slice": [%n1, %n2],
+		"prop_map": { "key1": %b1, "key2": %b2 },
+		"prop_slice_map": { "key1": [%n1, %n2], "key2": [%n2, %n1] },
+		"prop_map_slice": [{"key1": %f1}, {"key2": %f1}],
+		"prop_slice_map_slice": [{"key1": ["%s1"]}, {"key2": [%n1, %n1, %n2]} ],
+		
+		"bad_type":  true,
+		"not_a_slice": false,
+		"bad_slice_type": [38, 26],
+		"null_prop": null
+	}`
+
+	s1 := "value1"
+	n1 := int64(74)
+	n2 := int64(44)
+	b1 := true
+	b2 := false
+	f1 := float64(39.0001)
+
+	jsonString := strings.ReplaceAll(jsonTemplate, "%s1", s1)
+	jsonString = strings.ReplaceAll(jsonString, "%n1", fmt.Sprintf("%d", n1))
+	jsonString = strings.ReplaceAll(jsonString, "%n2", fmt.Sprintf("%d", n2))
+	jsonString = strings.ReplaceAll(jsonString, "%b1", "true")
+	jsonString = strings.ReplaceAll(jsonString, "%b2", "false")
+	jsonString = strings.ReplaceAll(jsonString, "%f1", fmt.Sprintf("%f", f1))
+
+	rawMap := unmarshalMap(jsonString)
+	assert.NotNil(t, rawMap)
+
+	model := new(MyModel)
+
+	var err error
+
+	// Positive tests
+	err = UnmarshalPrimitive(rawMap, "prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.Prop)
+	assert.Equal(t, s1, model.Prop.(string))
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, n1, int64(model.PropSlice[0].(float64)))
+	assert.Equal(t, n2, int64(model.PropSlice[1].(float64)))
+
+	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMap)
+	assert.Equal(t, b1, model.PropMap["key1"].(bool))
+	assert.Equal(t, b2, model.PropMap["key2"].(bool))
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMap)
+	assert.Equal(t, n1, int64(model.PropSliceMap["key1"][0].(float64)))
+	assert.Equal(t, n2, int64(model.PropSliceMap["key1"][1].(float64)))
+	assert.Equal(t, n2, int64(model.PropSliceMap["key2"][0].(float64)))
+	assert.Equal(t, n1, int64(model.PropSliceMap["key2"][1].(float64)))
+
+	err = UnmarshalPrimitive(rawMap, "prop_map_slice", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMapSlice)
+	assert.Equal(t, f1, model.PropMapSlice[0]["key1"].(float64))
+	assert.Equal(t, f1, model.PropMapSlice[1]["key2"].(float64))
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map_slice", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMapSlice)
+	assert.Equal(t, s1, model.PropSliceMapSlice[0]["key1"][0].(string))
+	assert.Equal(t, n1, int64(model.PropSliceMapSlice[1]["key2"][0].(float64)))
+	assert.Equal(t, n1, int64(model.PropSliceMapSlice[1]["key2"][1].(float64)))
+	assert.Equal(t, n2, int64(model.PropSliceMapSlice[1]["key2"][2].(float64)))
+
+	// Tests involving a JSON null value
+	model.Prop = "bad value"
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.Nil(t, model.Prop)
+
+	model.PropSlice = []interface{}{"bad1", "bad2"}
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSlice)
+
+	model.PropMap = map[string]interface{}{ "key1": "value1" }
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMapSlice)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMapSlice)
+
+	// Negative tests
+	model.Prop = nil
+	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.Prop)
+
+	err = UnmarshalPrimitive(rawMap, "not_a_slice", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'not_a_slice'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	model.PropSlice = nil
+	err = UnmarshalPrimitive(rawMap, "bad_slice_type", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+}
+
+func TestUnmarshalPrimitiveObject(t *testing.T) {
+	type MyModel struct {
+		Prop              map[string]interface{}
+		PropSlice         []map[string]interface{}
+		PropMap           map[string]map[string]interface{}
+		PropSliceMap      map[string][]map[string]interface{}
+		PropMapSlice      []map[string]map[string]interface{}
+		PropSliceMapSlice []map[string][]map[string]interface{}
+	}
+
+	jsonTemplate := `{
+		"prop": %o1,
+		"prop_slice": [%o1, %o2],
+		"prop_map": { "key1": %o1, "key2": %o2 },
+		"prop_slice_map": { "key1": [%o1, %o2], "key2": [%o2, %o1] },
+		"prop_map_slice": [{"key1": %o1}, {"key2": %o2}],
+		"prop_slice_map_slice": [{"key1": [%o1]}, {"key2": [%o1, %o1, %o2]} ],
+		
+		"bad_type":  true,
+		"not_a_slice": false,
+		"bad_slice_type": [38, 26],
+		"null_prop": null
+	}`
+	
+	o1 := `{"field1": "value1"}`
+	o2 := `{"field2": "value2"}`
+
+	jsonString := strings.ReplaceAll(jsonTemplate, "%o1", o1)
+	jsonString = strings.ReplaceAll(jsonString, "%o2", o2)
+
+	rawMap := unmarshalMap(jsonString)
+	assert.NotNil(t, rawMap)
+
+	model := new(MyModel)
+
+	var err error
+
+	// Positive tests
+	err = UnmarshalPrimitive(rawMap, "prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.Prop)
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+
+	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMap)
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMap)
+
+	err = UnmarshalPrimitive(rawMap, "prop_map_slice", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropMapSlice)
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_map_slice", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceMapSlice)
+
+	// Tests involving a JSON null value
+	model.Prop = make(map[string]interface{})
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.Prop)
+	assert.Nil(t, err)
+	assert.Nil(t, model.Prop)
+
+	model.PropSlice = make([]map[string]interface{}, 1)
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSlice)
+
+	model.PropMap = make(map[string]map[string]interface{})
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMap)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMap)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropMapSlice)
+
+	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMapSlice)
+	assert.Nil(t, err)
+	assert.Nil(t, model.PropSliceMapSlice)
+
+	// Negative tests
+	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_type'"))
+
+	err = UnmarshalPrimitive(rawMap, "not_a_slice", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'not_a_slice'"))
+	t.Logf("Expected error: %s\n", err.Error())
+
+	err = UnmarshalPrimitive(rawMap, "bad_slice_type", &model.PropSlice)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'bad_slice_type'"))
+}
+
+// Utility function that unmarshals a JSON string into a map containing RawMessage's.
+func unmarshalMap(jsonString string) (result map[string]json.RawMessage) {
+	err := json.Unmarshal([]byte(jsonString), &result)
+	if err != nil {
+		err := fmt.Errorf("Error unmarshalling initial json string %s\nerror: %s\n", jsonString, err.Error())
+		panic(err)
+	}
+	return
+}

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/IBM/go-sdk-core v3.0.0+incompatible h1:1QYh6UklIvEBW3qwVf2xDiFZtKa+PiDzdr9LcaTU4pA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/1613

This PR contains new unmarshal functions for primitive and model types in the Go core.
This will be needed in the SDK generator changes to fix the referenced issue.

The "new" approach for unmarshalling JSON values (primitives and models) in the Go generator will be to generate a single `Unmarshal<model>()` function for each model.   This generated function can then be passed as a parameter (along with the JSON input and a pointer to the unmarshal result) to the core's UnmarshalModel() function.  UnmarshalModel() will use reflection to interpret the JSON input and the result to determine the appropriate type of unmarshal operation (e.g. a single model instance, a slice of models, a map of models, or a map of model slices).

The new `UnmarshalPrimitive()` function will be invoked from within a model's generated `Unmarshal<model>()` function to unmarshal struct fields involving primitive types (e.g. a single instance of a primitive type, a slice of primitives, a map of primitives, a map of primitive slices, and a slice of maps of primitive slices).

This PR contains only the changes in the Go core.  There will be a corresponding PR for the SDK generator changes.

Note: there might be some additional tweaks needed to the code changes in this PR as I complete the corresponding SDK generator changes, but I wanted to get this PR submitted so the review process can begin.   One change that I identified as I reviewed the code before submitting this PR is that there is a common piece of code within each of the private unmarshalModelXXX functions that I can pull out and implement in a private function.   This will not change the overall behavior of those functions.