### PR TITLE
fix: allow = in config property values

### DIFF
--- a/core/config_utils.go
+++ b/core/config_utils.go
@@ -189,7 +189,7 @@ func parsePropertyStrings(credentialKey string, propertyStrings []string) map[st
 		}
 
 		// Parse the property string into name and value tokens
-		var tokens = strings.Split(propertyString, "=")
+		var tokens = strings.SplitN(propertyString, "=", 2)
 		if len(tokens) == 2 {
 			// Does the name start with the credential key?
 			// If so, then extract the property name by filtering out the credential key,

--- a/core/config_utils_test.go
+++ b/core/config_utils_test.go
@@ -46,6 +46,8 @@ var testEnvironment = map[string]string{
 	"SERVICE3_USERNAME":          "my-cp4d-user",
 	"SERVICE3_PASSWORD":          "my-cp4d-password",
 	"SERVICE3_AUTH_DISABLE_SSL":  "false",
+	"EQUAL_SERVICE_URL": "https://my=host.com/my=service/api",
+	"EQUAL_SERVICE_APIKEY": "===my=iam=apikey===",
 }
 
 // Set the environment variables described in our map.
@@ -124,6 +126,12 @@ func TestGetServicePropertiesFromCredentialFile(t *testing.T) {
 	assert.Equal(t, "https://cp4dhost/cp4d/api", props[PROPNAME_AUTH_URL])
 	assert.Equal(t, "false", props[PROPNAME_AUTH_DISABLE_SSL])
 
+	props, err = getServiceProperties("equal_service")
+	assert.Nil(t, err)
+	assert.NotNil(t, props)
+	assert.Equal(t, "=https:/my=host.com/my=service/api", props[PROPNAME_SVC_URL])
+	assert.Equal(t, "=my=api=key=", props[PROPNAME_APIKEY])
+
 	props, err = getServiceProperties("not_a_service")
 	assert.Nil(t, err)
 	assert.Nil(t, props)
@@ -165,6 +173,13 @@ func TestGetServicePropertiesFromEnvironment(t *testing.T) {
 	assert.Equal(t, "my-cp4d-password", props[PROPNAME_PASSWORD])
 	assert.Equal(t, "https://cp4dhost/cp4d/api", props[PROPNAME_AUTH_URL])
 	assert.Equal(t, "false", props[PROPNAME_AUTH_DISABLE_SSL])
+
+	props, err = getServiceProperties("equal_service")
+	assert.Nil(t, err)
+	assert.NotNil(t, props)
+	assert.Equal(t, "https://my=host.com/my=service/api", props[PROPNAME_SVC_URL])
+	assert.Equal(t, "===my=iam=apikey===", props[PROPNAME_APIKEY])
+	
 
 	props, err = getServiceProperties("not_a_service")
 	assert.Nil(t, err)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/go-openapi/strfmt v0.19.4
+	github.com/go-openapi/strfmt v0.19.5
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumC
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/go-openapi/errors v0.19.2 h1:a2kIyV3w+OS3S97zxUndRVD46+FhGOUBDFY7nmu4CsY=
 github.com/go-openapi/errors v0.19.2/go.mod h1:qX0BLWsyaKfvhluLejVpVNwNRdXZhEbTA4kxxpKBC94=
-github.com/go-openapi/strfmt v0.19.4 h1:eRvaqAhpL0IL6Trh5fDsGnGhiXndzHFuA05w6sXH6/g=
-github.com/go-openapi/strfmt v0.19.4/go.mod h1:eftuHTlB/dI8Uq8JJOyRlieZf+WkkxUuk0dgdHXr2Qk=
+github.com/go-openapi/strfmt v0.19.5 h1:0utjKrw+BAh8s57XE9Xz8DUBsVvPmRUB6styvl9wWIM=
+github.com/go-openapi/strfmt v0.19.5/go.mod h1:eftuHTlB/dI8Uq8JJOyRlieZf+WkkxUuk0dgdHXr2Qk=
 github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=

--- a/resources/my-credentials.env
+++ b/resources/my-credentials.env
@@ -41,6 +41,10 @@ SERVICE4_AUTH_TYPE=NOAuth
 SERVICE5_AUTH_TYPE=BEARERtoken
 SERVICE5_BEARER_TOKEN=my-bearer-token
 
+# EQUAL service exercises value with = in them
+EQUAL_SERVICE_URL==https:/my=host.com/my=service/api
+EQUAL_SERVICE_APIKEY==my=api=key=
+
 # Error1 - missing APIKEY
 ERROR1_AUTH_TYPE=iaM
 


### PR DESCRIPTION
This PR allows external config property values to contain an "=".
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/1759