### PR TITLE
Correctly handle nil pointer interfaces in RequestBuilder.SetBodyContent

### DIFF
--- a/v4/core/request_builder.go
+++ b/v4/core/request_builder.go
@@ -264,12 +264,12 @@ func (requestBuilder *RequestBuilder) Build() (*http.Request, error) {
 // SetBodyContent sets the body content from one of three different sources.
 func (requestBuilder *RequestBuilder) SetBodyContent(contentType string, jsonContent interface{}, jsonPatchContent interface{},
 	nonJSONContent interface{}) (builder *RequestBuilder, err error) {
-	if jsonContent != nil {
+	if !isNil(jsonContent) {
 		builder, err = requestBuilder.SetBodyContentJSON(jsonContent)
 		if err != nil {
 			return
 		}
-	} else if jsonPatchContent != nil {
+	} else if !isNil(jsonPatchContent) {
 		builder, err = requestBuilder.SetBodyContentJSON(jsonPatchContent)
 		if err != nil {
 			return

--- a/v4/core/request_builder_test.go
+++ b/v4/core/request_builder_test.go
@@ -168,6 +168,18 @@ func TestSetBodyContent2(t *testing.T) {
 	assert.Equal(t, str, readStream(request.Body))
 }
 
+// Test the case when SetBodyContent is given a nil pointer for jsonContent.
+func TestSetBodyContent3(t *testing.T) {
+	var (
+		str  = "hello GO SDK"
+		json *string
+	)
+	request := setup()
+	_, _ = request.SetBodyContent("text/plain", json, nil, &str)
+	assert.NotNil(t, request.Body)
+	assert.Equal(t, str, readStream(request.Body))
+}
+
 func TestSetBodyContentError(t *testing.T) {
 	request := setup()
 	_, err := request.SetBodyContent("", nil, nil, 200)


### PR DESCRIPTION
`RequestBuilder.SetBodyContent` currently does not correctly handle the case when its `interface{}` arguments are nil pointers. 

In Go, a `interface{}(*string)(nil)` is not the same as `nil`. This is because `interface{}`s are essentially a box containing an underlying type and value; there are cases where this method is given arguments where the box contains an empty pointer, but the box itself is not `nil`, thereby causing the wrong body contents to be set.

I discovered this bug when trying (and failing) to use plain text with IBM's Tone Analysis API and always getting an empty reply. This is because `SetBodyContent` always encodes with the (nil) `jsonContent` instead of the (non-nil) plaintext body.

See the following delve debug logs for more information:
<img width="868" alt="image" src="https://user-images.githubusercontent.com/1376678/84286284-7c349700-ab0c-11ea-83e3-3ee216a304b3.png">
