### PR TITLE
fix: improve error paths in BaseService.Request()

### DIFF
--- a/v4/core/base_service.go
+++ b/v4/core/base_service.go
@@ -221,6 +221,7 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 
 	err = service.Options.Authenticator.Authenticate(req)
 	if err != nil {
+		err = fmt.Errorf(ERRORMSG_AUTHENTICATE_ERROR, err.Error())
 		return
 	}
 
@@ -254,7 +255,7 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 			defer httpResponse.Body.Close()
 			responseBody, readErr = ioutil.ReadAll(httpResponse.Body)
 			if readErr != nil {
-				err = fmt.Errorf("An error occurred while reading the response body: '%s'", readErr.Error())
+				err = fmt.Errorf(ERRORMSG_READ_RESPONSE_BODY, readErr.Error())
 				return
 			}
 		}
@@ -301,7 +302,7 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 			defer httpResponse.Body.Close()
 			responseBody, readErr := ioutil.ReadAll(httpResponse.Body)
 			if readErr != nil {
-				err = fmt.Errorf("An error occurred while reading the response body: '%s'", readErr.Error())
+				err = fmt.Errorf(ERRORMSG_READ_RESPONSE_BODY, readErr.Error())
 				return
 			}
 
@@ -310,7 +311,7 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 			if decodeErr != nil {
 				// Error decoding the response body.
 				// Return the response body in RawResult, along with an error.
-				err = fmt.Errorf("An error occurred while unmarshalling the response body: '%s'", decodeErr.Error())
+				err = fmt.Errorf(ERRORMSG_UNMARSHAL_RESPONSE_BODY, decodeErr.Error())
 				detailedResponse.RawResult = responseBody
 				return
 			}
@@ -325,7 +326,7 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 			defer httpResponse.Body.Close()
 			responseBody, readErr := ioutil.ReadAll(httpResponse.Body)
 			if readErr != nil {
-				err = fmt.Errorf("An error occurred while reading the response body: '%s'", readErr.Error())
+				err = fmt.Errorf(ERRORMSG_READ_RESPONSE_BODY, readErr.Error())
 				return
 			}
 			

--- a/v4/core/base_service_test.go
+++ b/v4/core/base_service_test.go
@@ -889,7 +889,7 @@ func TestIAMFailure(t *testing.T) {
 	var foo *Foo
 	_, err = service.Request(req, &foo)
 	assert.NotNil(t, err)
-	assert.Equal(t, "Sorry you are forbidden", err.Error())
+	assert.Contains(t, err.Error(), "Sorry you are forbidden")
 }
 
 func TestIAMWithIdSecret(t *testing.T) {
@@ -1053,7 +1053,7 @@ func TestCP4DFail(t *testing.T) {
 
 	var foo *Foo
 	_, err = service.Request(req, &foo)
-	assert.Equal(t, "Sorry you are forbidden", err.Error())
+	assert.Contains(t, err.Error(), "Sorry you are forbidden")
 }
 
 // Test for the deprecated SetURL method.

--- a/v4/core/constants.go
+++ b/v4/core/constants.go
@@ -53,4 +53,7 @@ const (
 		"self-signed certificate, disable verification of the server's SSL certificate " +
 		"by invoking the DisableSSLVerification() function on your service instance " +
 		"and/or use the DisableSSLVerification option of the authenticator."
+	ERRORMSG_AUTHENTICATE_ERROR      = "An error occurred while performing the 'authenticate' step: %s"
+	ERRORMSG_READ_RESPONSE_BODY      = "An error occurred while reading the response body: %s"
+	ERRORMSG_UNMARSHAL_RESPONSE_BODY = "An error occurred while unmarshalling the response body: %s"
 )


### PR DESCRIPTION
This PR improves error reporting inside BaseService.Request().