### PR TITLE
feat: rename isNil to be IsNil (public)

### DIFF
--- a/v4/core/base_service.go
+++ b/v4/core/base_service.go
@@ -185,13 +185,13 @@ func (service *BaseService) SetUserAgent(userAgentString string) {
 
 //
 // Request invokes the specified HTTP request and returns the response.
-// 
+//
 // Parameters:
 // req: the http.Request object that holds the request information
 //
 // result: a pointer to the operation result.  This should be one of:
 //   - *io.ReadCloser (for a byte-stream type response)
-//   - *<primitive>, *[]<primitive>, *map[string]<primitive> 
+//   - *<primitive>, *[]<primitive>, *map[string]<primitive>
 //   - *map[string]json.RawMessage, *[]json.RawMessage
 //
 // Return values:
@@ -287,8 +287,8 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 	}
 
 	// Operation was successful and we are expecting a response, so process the response.
-	if !isNil(result) {
-		
+	if !IsNil(result) {
+
 		// If 'result' is a io.ReadCloser, then pass the response body back reflectively via 'result'
 		// and bypass any further unmarshalling of the response.
 		if reflect.TypeOf(result).String() == "*io.ReadCloser" {
@@ -329,16 +329,16 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 				err = fmt.Errorf(ERRORMSG_READ_RESPONSE_BODY, readErr.Error())
 				return
 			}
-			
+
 			// After reading the response body into a []byte, check to see if the caller wanted the
 			// response body as a string.
-			// If the caller passed in 'result' as the address of *string, 
-			// then we'll reflectively set result to point to it.			
+			// If the caller passed in 'result' as the address of *string,
+			// then we'll reflectively set result to point to it.
 			if reflect.TypeOf(result).String() == "**string" {
 				responseString := string(responseBody)
 				rResult := reflect.ValueOf(result).Elem()
 				rResult.Set(reflect.ValueOf(&responseString))
-				
+
 				// And set the string in the Result field.
 				detailedResponse.Result = &responseString
 			} else {

--- a/v4/core/request_builder.go
+++ b/v4/core/request_builder.go
@@ -264,12 +264,12 @@ func (requestBuilder *RequestBuilder) Build() (*http.Request, error) {
 // SetBodyContent sets the body content from one of three different sources.
 func (requestBuilder *RequestBuilder) SetBodyContent(contentType string, jsonContent interface{}, jsonPatchContent interface{},
 	nonJSONContent interface{}) (builder *RequestBuilder, err error) {
-	if !isNil(jsonContent) {
+	if !IsNil(jsonContent) {
 		builder, err = requestBuilder.SetBodyContentJSON(jsonContent)
 		if err != nil {
 			return
 		}
-	} else if !isNil(jsonPatchContent) {
+	} else if !IsNil(jsonPatchContent) {
 		builder, err = requestBuilder.SetBodyContentJSON(jsonPatchContent)
 		if err != nil {
 			return

--- a/v4/core/utils.go
+++ b/v4/core/utils.go
@@ -40,8 +40,8 @@ const (
 	jsonPatchMimePattern = "(?i)^application\\/json\\-patch\\+json(;.*)?$"
 )
 
-// isNil checks if the specified object is nil or not.
-func isNil(object interface{}) bool {
+// IsNil checks if the specified object is nil or not.
+func IsNil(object interface{}) bool {
 	if object == nil {
 		return true
 	}
@@ -56,7 +56,7 @@ func isNil(object interface{}) bool {
 
 // ValidateNotNil returns the specified error if 'object' is nil, nil otherwise.
 func ValidateNotNil(object interface{}, errorMsg string) error {
-	if isNil(object) {
+	if IsNil(object) {
 		return errors.New(errorMsg)
 	}
 	return nil
@@ -65,7 +65,7 @@ func ValidateNotNil(object interface{}, errorMsg string) error {
 // ValidateStruct validates 'param' (assumed to be a ptr to a struct) according to the
 // annotations attached to its fields.
 func ValidateStruct(param interface{}, paramName string) error {
-	err := ValidateNotNil(param, paramName + " cannot be nil")
+	err := ValidateNotNil(param, paramName+" cannot be nil")
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func ValidateStruct(param interface{}, paramName string) error {
 		}
 		return err
 	}
-	
+
 	return nil
 }
 

--- a/v4/core/utils_test.go
+++ b/v4/core/utils_test.go
@@ -68,8 +68,8 @@ func TestValidateNotNil(t *testing.T) {
 }
 
 func TestIsNil(t *testing.T) {
-	assert.Equal(t, true, isNil(nil))
-	assert.Equal(t, false, isNil("test"))
+	assert.Equal(t, true, IsNil(nil))
+	assert.Equal(t, false, IsNil("test"))
 }
 
 func TestValidateStruct(t *testing.T) {
@@ -79,16 +79,16 @@ func TestValidateStruct(t *testing.T) {
 	}
 
 	type User struct {
-		FirstName *string    `json:"fname" validate:"required"`
-		LastName  *string    `json:"lname" validate:"required"`
-		Addresses []Address  `json:"address" validate:"dive"`
+		FirstName *string   `json:"fname" validate:"required"`
+		LastName  *string   `json:"lname" validate:"required"`
+		Addresses []Address `json:"address" validate:"dive"`
 	}
-	
+
 	type NoRequiredFields struct {
-		FirstName *string    `json:"fname"`
-		LastName  *string    `json:"lname"`
+		FirstName *string `json:"fname"`
+		LastName  *string `json:"lname"`
 	}
-	
+
 	address := &Address{
 		Street: "Eavesdown Docks",
 		City:   "",
@@ -110,29 +110,29 @@ func TestValidateStruct(t *testing.T) {
 	badStruct := &Address{
 		Street: "Beltorre Drive",
 	}
-	
+
 	noReqFields := &NoRequiredFields{}
 
 	var err error
-	
+
 	err = ValidateStruct(goodStruct, "goodStruct")
 	assert.Nil(t, err)
-	
+
 	err = ValidateStruct(noReqFields, "noReqFields")
 	assert.Nil(t, err)
-	
+
 	err = ValidateStruct(user, "userPtr")
 	assert.NotNil(t, err)
 	t.Logf("[01] Expected error: %s\n", err.Error())
-	
+
 	err = ValidateStruct(nil, "nilPtr")
-	assert.NotNil(t, err )
+	assert.NotNil(t, err)
 	t.Logf("[02] Expected error: %s\n", err.Error())
-	
+
 	err = ValidateStruct(badStruct, "badStruct")
 	assert.NotNil(t, err)
 	t.Logf("[03] Expected error: %s\n", err.Error())
-	
+
 	var addressPtr *Address = nil
 	err = ValidateStruct(addressPtr, "addressPtr")
 	assert.NotNil(t, err)


### PR DESCRIPTION
This PR renames the `isNil()` method to be `IsNil()` to make it public so that it can be used by generated code.