### PR TITLE
fix: expose AuthenticationError.Err field and add ctor

### DIFF
--- a/v4/core/authenticator.go
+++ b/v4/core/authenticator.go
@@ -28,9 +28,16 @@ type Authenticator interface {
 // AuthenticationError describes the error returned when authentication fails
 type AuthenticationError struct {
 	Response *DetailedResponse
-	err      error
+	Err      error
 }
 
 func (e *AuthenticationError) Error() string {
-	return e.err.Error()
+	return e.Err.Error()
+}
+
+func NewAuthenticationError(response *DetailedResponse, err error) (*AuthenticationError) {
+	return &AuthenticationError{
+		Response: response,
+		Err: err,
+	}
 }

--- a/v4/core/cp4d_authenticator.go
+++ b/v4/core/cp4d_authenticator.go
@@ -260,18 +260,15 @@ func (authenticator *CloudPakForDataAuthenticator) requestToken() (*cp4dTokenSer
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		buff := new(bytes.Buffer)
 		_, _ = buff.ReadFrom(resp.Body)
-		// Start to populate the DetailedResponse.
+
+		// Create a DetailedResponse to be included in the error below.
 		detailedResponse := &DetailedResponse{
 			StatusCode: resp.StatusCode,
 			Headers:    resp.Header,
 			RawResult:  buff.Bytes(),
 		}
-		// Return a AuthenticationError in place of a generic "error"
-		authError := &AuthenticationError{
-			Response: detailedResponse,
-			err:      fmt.Errorf(buff.String()),
-		}
-		return nil, authError
+
+		return nil, NewAuthenticationError(detailedResponse, fmt.Errorf(buff.String()))
 	}
 
 	tokenResponse := &cp4dTokenServerResponse{}

--- a/v4/core/iam_authenticator.go
+++ b/v4/core/iam_authenticator.go
@@ -292,18 +292,15 @@ func (authenticator *IamAuthenticator) requestToken() (*iamTokenServerResponse, 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		buff := new(bytes.Buffer)
 		_, _ = buff.ReadFrom(resp.Body)
-		// Start to populate the DetailedResponse.
+
+		// Create a DetailedResponse to be included in the error below.
 		detailedResponse := &DetailedResponse{
 			StatusCode: resp.StatusCode,
 			Headers:    resp.Header,
 			RawResult:  buff.Bytes(),
 		}
-		// Return a AuthenticationError in place of a generic "error"
-		authError := &AuthenticationError{
-			Response: detailedResponse,
-			err:      fmt.Errorf(buff.String()),
-		}
-		return nil, authError
+		
+		return nil, NewAuthenticationError(detailedResponse, fmt.Errorf(buff.String()))
 	}
 
 	tokenResponse := &iamTokenServerResponse{}


### PR DESCRIPTION
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/2144

This PR makes the "err" field public (i.e. "Err") and adds the `NewAuthenticationError()` ctor function.