### PR TITLE
feat(IAM Authenticator): add support for optional 'scope' property

### DIFF
--- a/v4/core/authenticator_factory_test.go
+++ b/v4/core/authenticator_factory_test.go
@@ -48,6 +48,15 @@ func TestGetAuthenticatorFromEnvironment1(t *testing.T) {
 	assert.NotNil(t, authenticator)
 	assert.Equal(t, AUTHTYPE_CP4D, authenticator.AuthenticationType())
 
+	authenticator, err = GetAuthenticatorFromEnvironment("service6")
+	assert.Nil(t, err)
+	assert.NotNil(t, authenticator)
+	assert.Equal(t, AUTHTYPE_IAM, authenticator.AuthenticationType())
+	iamAuthenticator, ok := authenticator.(*IamAuthenticator)
+	assert.True(t, ok)
+	assert.NotNil(t, iamAuthenticator)
+	assert.Equal(t, "scope1 scope2 scope3", iamAuthenticator.Scope)
+
 	os.Unsetenv("IBM_CREDENTIALS_FILE")
 }
 

--- a/v4/core/config_utils_test.go
+++ b/v4/core/config_utils_test.go
@@ -48,6 +48,9 @@ var testEnvironment = map[string]string{
 	"SERVICE3_AUTH_DISABLE_SSL":  "false",
 	"EQUAL_SERVICE_URL":          "https://my=host.com/my=service/api",
 	"EQUAL_SERVICE_APIKEY":       "===my=iam=apikey===",
+	"SERVICE6_AUTH_TYPE":         "iam",
+	"SERVICE6_APIKEY":            "my-api-key",
+	"SERVICE6_SCOPE":             "A B C D",
 }
 
 // Set the environment variables described in our map.
@@ -136,6 +139,14 @@ func TestGetServicePropertiesFromCredentialFile(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, props)
 
+	props, err = getServiceProperties("service6")
+	assert.Nil(t, err)
+	assert.NotNil(t, props)
+	assert.Equal(t, "IAM", props[PROPNAME_AUTH_TYPE])
+	assert.Equal(t, "my-api-key", props[PROPNAME_APIKEY])
+	assert.Equal(t, "https://iamhost/iam/api", props[PROPNAME_AUTH_URL])
+	assert.Equal(t, "scope1 scope2 scope3", props[PROPNAME_SCOPE])
+
 	os.Unsetenv("IBM_CREDENTIALS_FILE")
 }
 
@@ -183,6 +194,13 @@ func TestGetServicePropertiesFromEnvironment(t *testing.T) {
 	props, err = getServiceProperties("not_a_service")
 	assert.Nil(t, err)
 	assert.Nil(t, props)
+
+	props, err = getServiceProperties("service6")
+	assert.Nil(t, err)
+	assert.NotNil(t, props)
+	assert.Equal(t, "iam", props[PROPNAME_AUTH_TYPE])
+	assert.Equal(t, "my-api-key", props[PROPNAME_APIKEY])
+	assert.Equal(t, "A B C D", props[PROPNAME_SCOPE])
 
 	clearTestEnvironment()
 	assert.Equal(t, "", os.Getenv("SERVICE_1_URL"))

--- a/v4/core/constants.go
+++ b/v4/core/constants.go
@@ -39,6 +39,7 @@ const (
 	PROPNAME_APIKEY           = "APIKEY"
 	PROPNAME_CLIENT_ID        = "CLIENT_ID"
 	PROPNAME_CLIENT_SECRET    = "CLIENT_SECRET"
+	PROPNAME_SCOPE            = "SCOPE"
 
 	// SSL error
 	SSL_CERTIFICATION_ERROR = "x509: certificate"

--- a/v4/resources/my-credentials.env
+++ b/v4/resources/my-credentials.env
@@ -41,6 +41,12 @@ SERVICE4_AUTH_TYPE=NOAuth
 SERVICE5_AUTH_TYPE=BEARERtoken
 SERVICE5_BEARER_TOKEN=my-bearer-token
 
+# Service6 configured with IAM w/scope
+SERVICE6_AUTH_TYPE=IAM
+SERVICE6_APIKEY=my-api-key
+SERVICE6_AUTH_URL=https://iamhost/iam/api
+SERVICE6_SCOPE=scope1 scope2 scope3
+
 # EQUAL service exercises value with = in them
 EQUAL_SERVICE_URL==https:/my=host.com/my=service/api
 EQUAL_SERVICE_APIKEY==my=api=key=


### PR DESCRIPTION
The IAM /identity/token (get token)  operation supports an optional "scope"
form parameter which can be used to obtain an IAM access token
having a limited set of scopes in this it can be used.
This commit adds support for the "Scope" field within
the IamAuthenticator struct.  If set, the value of this field
is sent as the "scope" form param in the "get token"
request body when obtaining an access token.