### PR TITLE
fix: dont panic in SetBodyContent when nonJSONContent is nil

### DIFF
--- a/v4/core/request_builder.go
+++ b/v4/core/request_builder.go
@@ -340,7 +340,7 @@ func (requestBuilder *RequestBuilder) SetBodyContent(contentType string, jsonCon
 		if err != nil {
 			return
 		}
-	} else {
+	} else if !IsNil(nonJSONContent) {
 		// Set the non-JSON body content based on the type of value passed in,
 		// which should be a "string", "*string" or an "io.Reader"
 		if str, ok := nonJSONContent.(string); ok {
@@ -355,6 +355,9 @@ func (requestBuilder *RequestBuilder) SetBodyContent(contentType string, jsonCon
 			builder = requestBuilder
 			err = fmt.Errorf("Invalid type for non-JSON body content: %s", reflect.TypeOf(nonJSONContent).String())
 		}
+	} else {
+		builder = requestBuilder
+		err = fmt.Errorf("No body content provided")
 	}
 	return
 }

--- a/v4/core/request_builder_test.go
+++ b/v4/core/request_builder_test.go
@@ -301,6 +301,13 @@ func TestSetBodyContentError(t *testing.T) {
 	assert.Equal(t, err.Error(), "Invalid type for non-JSON body content: int")
 }
 
+func TestSetBodyContentNoContent(t *testing.T) {
+	request := setup()
+	_, err := request.SetBodyContent("", nil, nil, nil)
+	assert.Nil(t, request.Body)
+	assert.Equal(t, err.Error(), "No body content provided")
+}
+
 func TestBuildWithMultipartFormEmptyFileName(t *testing.T) {
 	builder := NewRequestBuilder("POST")
 	_, err := builder.ConstructHTTPURL("test.com", nil, nil)


### PR DESCRIPTION
Fixes a bug in which not setting any body type lead to an attempt to reflect the type of a `nil` object, which caused a panic. Explicitly handles the case in which all three potential body objects are `nil`. Adds a test for this case.