### PR TITLE
fix: expose IamAuthenticator.requestToken as a public method

### DIFF
--- a/v4/core/iam_authenticator.go
+++ b/v4/core/iam_authenticator.go
@@ -230,7 +230,7 @@ func (authenticator *IamAuthenticator) synchronizedRequestToken() error {
 // unmarshals the token information to the tokenData cache. Returns
 // an error if the token was unable to be fetched, otherwise returns nil
 func (authenticator *IamAuthenticator) getTokenData() error {
-	tokenResponse, err := authenticator.requestToken()
+	tokenResponse, err := authenticator.RequestToken()
 	if err != nil {
 		return err
 	}
@@ -243,8 +243,8 @@ func (authenticator *IamAuthenticator) getTokenData() error {
 	return nil
 }
 
-// requestToken: fetches a new access token from the token server.
-func (authenticator *IamAuthenticator) requestToken() (*iamTokenServerResponse, error) {
+// RequestToken: fetches a new access token from the token server.
+func (authenticator *IamAuthenticator) RequestToken() (*IamTokenServerResponse, error) {
 	// Use the default IAM URL if one was not specified by the user.
 	url := authenticator.URL
 	if url == "" {
@@ -262,7 +262,7 @@ func (authenticator *IamAuthenticator) requestToken() (*iamTokenServerResponse, 
 		AddFormData("grant_type", "", "", REQUEST_TOKEN_GRANT_TYPE).
 		AddFormData("apikey", "", "", authenticator.ApiKey).
 		AddFormData("response_type", "", "", REQUEST_TOKEN_RESPONSE_TYPE)
-	
+
 	// Add any optional parameters to the request.
 	if authenticator.Scope != "" {
 		builder.AddFormData("scope", "", "", authenticator.Scope)
@@ -317,14 +317,14 @@ func (authenticator *IamAuthenticator) requestToken() (*iamTokenServerResponse, 
 		return nil, NewAuthenticationError(detailedResponse, fmt.Errorf(buff.String()))
 	}
 
-	tokenResponse := &iamTokenServerResponse{}
+	tokenResponse := &IamTokenServerResponse{}
 	_ = json.NewDecoder(resp.Body).Decode(tokenResponse)
 	defer resp.Body.Close()
 	return tokenResponse, nil
 }
 
-// iamTokenServerResponse : This struct models a response received from the token server.
-type iamTokenServerResponse struct {
+// IamTokenServerResponse : This struct models a response received from the token server.
+type IamTokenServerResponse struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
 	TokenType    string `json:"token_type"`
@@ -340,7 +340,7 @@ type iamTokenData struct {
 }
 
 // newIamTokenData: constructs a new IamTokenData instance from the specified IamTokenServerResponse instance.
-func newIamTokenData(tokenResponse *iamTokenServerResponse) (*iamTokenData, error) {
+func newIamTokenData(tokenResponse *IamTokenServerResponse) (*iamTokenData, error) {
 
 	if tokenResponse == nil {
 		return nil, fmt.Errorf("Error while trying to parse access token!")

--- a/v4/core/iam_authenticator_test.go
+++ b/v4/core/iam_authenticator_test.go
@@ -27,6 +27,7 @@ import (
 var (
 	AccessToken1 string = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI"
 	AccessToken2 string = "3yJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI"
+	RefreshToken string = "Xj7Gle500MachEOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI"
 )
 
 func TestIamConfigErrors(t *testing.T) {
@@ -98,8 +99,8 @@ func TestIamGetTokenSuccess(t *testing.T) {
 				"token_type": "Bearer",
 				"expires_in": 3600,
 				"expiration": %d,
-				"refresh_token": "jy4gl91BQ"
-			}`, AccessToken1, expiration)
+				"refresh_token": "%s"
+			}`, AccessToken1, expiration, RefreshToken)
 			firstCall = false
 			_, _, ok := r.BasicAuth()
 			assert.False(t, ok)
@@ -109,8 +110,8 @@ func TestIamGetTokenSuccess(t *testing.T) {
 				"token_type": "Bearer",
 				"expires_in": 3600,
 				"expiration": %d,
-				"refresh_token": "jy4gl91BQ"
-			}`, AccessToken2, expiration)
+				"refresh_token": "%s"
+			}`, AccessToken2, expiration, RefreshToken)
 			username, password, ok := r.BasicAuth()
 			assert.True(t, ok)
 			assert.Equal(t, "mookie", username)
@@ -137,6 +138,12 @@ func TestIamGetTokenSuccess(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, authenticator.tokenData)
 	assert.Equal(t, AccessToken2, authenticator.tokenData.AccessToken)
+
+	// Test the RequestToken() method to make sure we can get a RefreshToken.
+	tokenResponse, err := authenticator.RequestToken()
+	assert.Nil(t, err)
+	assert.NotNil(t, tokenResponse)
+	assert.Equal(t, RefreshToken, tokenResponse.RefreshToken)
 }
 
 func TestIamGetTokenSuccessWithScope(t *testing.T) {
@@ -470,7 +477,7 @@ func TestIamRefreshTimeCalculation(t *testing.T) {
 	const expected int64 = expireTime - 720 // 720 is 20% of 3600
 
 	// Simulate a token server response.
-	tokenResponse := &iamTokenServerResponse{
+	tokenResponse := &IamTokenServerResponse{
 		ExpiresIn:  timeToLive,
 		Expiration: expireTime,
 	}


### PR DESCRIPTION
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/2215

This PR exposes IamAuthenticator.requestToken() as a public method, along with the IamTokenServerResponse struct which is returned by requestToken().