### PR TITLE
feat: support use of Context with RequestBuilder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - sudo apt-get install python
 
 install:
-  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.21.0
+  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.31.0
 
 script:
   - make all

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,9 +30,9 @@ If you want to contribute to the repository, here's a quick guide:
   
   4. Install the `golangci-lint` tool:
      ```sh
-     curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.21.0
+     curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.31.0
      ```  
-  * Note: As of this writing, the 1.21.0 version of `golangci-lint` is being used by this project.
+  * Note: As of this writing, the 1.31.0 version of `golangci-lint` is being used by this project.
   Please check the `curl` command found in the `.travis.yml` file to see the version of this tool that is currently 
   being used at the time you are planning to commit changes. This will ensure that you are using the same version 
   of the linter as the Travis build automation, which will ensure that you are using the same set of linter checks
@@ -42,12 +42,12 @@ If you want to contribute to the repository, here's a quick guide:
   
   6. Test your changes:
      ```sh
-     go test ./...
+     make test
      ```  
   
   7. Check your code for lint issues
      ```sh
-     golangci-lint run
+     make lint
      ```  
   
   8. Commit your changes:

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Before opening a new issue, please search for similar issues. It's possible that
 
 ## Tests
 
-Run all test suites:
+To build, test and lint-check the project:
 ```bash
-go test ./...
+make all
 ```
 
 Get code coverage for each test suite:

--- a/v4/core/request_builder.go
+++ b/v4/core/request_builder.go
@@ -16,6 +16,7 @@ package core
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -76,6 +77,10 @@ type RequestBuilder struct {
 	// the "Content-Encoding" header will be added to the request with the
 	// value "gzip".
 	EnableGzipCompression bool
+
+	// RequestContext is an optional Context instance to be associated with the
+	// http.Request that is constructed by the Build() method.
+	ctx context.Context
 }
 
 // NewRequestBuilder initiates a new request.
@@ -86,6 +91,13 @@ func NewRequestBuilder(method string) *RequestBuilder {
 		Query:  make(map[string][]string),
 		Form:   make(map[string][]FormData),
 	}
+}
+
+// WithContext sets "ctx" as the Context to be associated with
+// the http.Request instance that will be constructed by the Build() method.
+func (requestBuilder *RequestBuilder) WithContext(ctx context.Context) *RequestBuilder {
+	requestBuilder.ctx = ctx
+	return requestBuilder
 }
 
 // ConstructHTTPURL creates a properly-encoded URL with path parameters.
@@ -275,7 +287,7 @@ func (requestBuilder *RequestBuilder) SetBodyContentForMultipart(contentType str
 }
 
 // Build builds an HTTP Request object from this RequestBuilder instance.
-func (requestBuilder *RequestBuilder) Build() (*http.Request, error) {
+func (requestBuilder *RequestBuilder) Build() (req *http.Request, err error) {
 	// Create multipart form data
 	if len(requestBuilder.Form) > 0 {
 		// handle both application/x-www-form-urlencoded or multipart/form-data
@@ -287,29 +299,30 @@ func (requestBuilder *RequestBuilder) Build() (*http.Request, error) {
 					data.Add(fieldName, v.contents.(string))
 				}
 			}
-			_, err := requestBuilder.SetBodyContentString(data.Encode())
+			_, err = requestBuilder.SetBodyContentString(data.Encode())
 			if err != nil {
-				return nil, err
+				return
 			}
 		} else {
 			formWriter := requestBuilder.createMultipartWriter()
 			for fieldName, l := range requestBuilder.Form {
 				for _, v := range l {
-					dataPartWriter, err := createFormFile(formWriter, fieldName, v.fileName, v.contentType)
+					var dataPartWriter io.Writer
+					dataPartWriter, err = createFormFile(formWriter, fieldName, v.fileName, v.contentType)
 					if err != nil {
-						return nil, err
+						return
 					}
 					if err = requestBuilder.SetBodyContentForMultipart(v.contentType,
 						v.contents, dataPartWriter); err != nil {
-						return nil, err
+						return
 					}
 				}
 			}
 
 			requestBuilder.AddHeader("Content-Type", formWriter.FormDataContentType())
-			err := formWriter.Close()
+			err = formWriter.Close()
 			if err != nil {
-				return nil, err
+				return
 			}
 		}
 	}
@@ -327,9 +340,9 @@ func (requestBuilder *RequestBuilder) Build() (*http.Request, error) {
 	}
 
 	// Create the request
-	req, err := http.NewRequest(requestBuilder.Method, requestBuilder.URL.String(), requestBuilder.Body)
+	req, err = http.NewRequest(requestBuilder.Method, requestBuilder.URL.String(), requestBuilder.Body)
 	if err != nil {
-		return nil, err
+		return
 	}
 
 	// Headers
@@ -342,10 +355,16 @@ func (requestBuilder *RequestBuilder) Build() (*http.Request, error) {
 			query.Add(k, v)
 		}
 	}
+
 	// Encode query
 	req.URL.RawQuery = query.Encode()
 
-	return req, nil
+	// Finally, if a Context should be associated with the new Request instance, then set it.
+	if !IsNil(requestBuilder.ctx) {
+		req = req.WithContext(requestBuilder.ctx)
+	}
+
+	return
 }
 
 // SetBodyContent sets the body content from one of three different sources.

--- a/v4/core/request_builder_test.go
+++ b/v4/core/request_builder_test.go
@@ -16,9 +16,14 @@ package core
 
 import (
 	"bytes"
+	"context"
+	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	assert "github.com/stretchr/testify/assert"
 )
@@ -592,4 +597,79 @@ func TestBuild(t *testing.T) {
 	assert.NotNil(t, request)
 	assert.Equal(t, wantURL, request.URL.String())
 	assert.Equal(t, "Application/json", request.Header["Content-Type"][0])
+}
+
+func TestRequestWithContext(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"name": "wonder woman"}`)
+	}))
+	defer server.Close()
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancelFunc()
+
+	builder := NewRequestBuilder("GET")
+	builder = builder.WithContext(ctx)
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	req, _ := builder.Build()
+
+	authenticator, _ := NewNoAuthAuthenticator()
+
+	options := &ServiceOptions{
+		URL:           server.URL,
+		Authenticator: authenticator,
+	}
+	service, err := NewBaseService(options)
+	assert.Nil(t, err)
+
+	var foo *Foo
+	detailedResponse, err := service.Request(req, &foo)
+	assert.Nil(t, err)
+	assert.NotNil(t, detailedResponse)
+	assert.Equal(t, http.StatusOK, detailedResponse.StatusCode)
+	assert.Equal(t, "application/json", detailedResponse.Headers.Get("Content-Type"))
+
+	result, ok := detailedResponse.Result.(*Foo)
+	assert.Equal(t, true, ok)
+	assert.NotNil(t, result)
+	assert.NotNil(t, foo)
+	assert.Equal(t, "wonder woman", *(result.Name))
+}
+
+func TestRequestWithContextTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		time.Sleep(2 * time.Second)
+		fmt.Fprint(w, `{"name": "wonder woman"}`)
+	}))
+	defer server.Close()
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancelFunc()
+
+	builder := NewRequestBuilder("GET")
+	builder = builder.WithContext(ctx)
+	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	assert.Nil(t, err)
+	req, _ := builder.Build()
+
+	authenticator, _ := NewNoAuthAuthenticator()
+
+	options := &ServiceOptions{
+		URL:           server.URL,
+		Authenticator: authenticator,
+	}
+	service, err := NewBaseService(options)
+	assert.Nil(t, err)
+
+	var foo *Foo
+	detailedResponse, err := service.Request(req, &foo)
+	assert.NotNil(t, err)
+	t.Logf("Expected error: %s\n", err.Error())
+	assert.Contains(t, err.Error(), "context deadline exceeded")
+	assert.Nil(t, detailedResponse)
 }


### PR DESCRIPTION
Fixes arf/planning-sdk-squad#2230
Fixes #77

This commit adds support for setting a Context
instance on the RequestBuilder struct.  This Context instance
will then be associated with the http.Request instance constructed
by the RequestBuilder.Build() method.
The Context can be used to define a timeout/deadline for a request
or to cancel an in-flight request.