### PR TITLE
Update gateway url

### DIFF
--- a/v4/core/config_utils_test.go
+++ b/v4/core/config_utils_test.go
@@ -260,7 +260,7 @@ func TestLoadFromVCAPServicesWithInvalidJSON(t *testing.T) {
 	vcapServicesFail := `{
 		"watson": [
 			"credentials": {
-				"url": "https://gateway.watsonplatform.net/compare-comply/api",
+				"url": "https://api.us-south.compare-comply.watson.cloud.ibm.com",
 				"username": "bogus username",
 				"password": "bogus password",
 				"apikey": "bogus apikey"

--- a/v4/core/request_builder_test.go
+++ b/v4/core/request_builder_test.go
@@ -133,39 +133,39 @@ func TestResolveRequestURLErrors(t *testing.T) {
 }
 
 func TestConstructHTTPURL(t *testing.T) {
-	endPoint := "https://gateway.watsonplatform.net/assistant/api"
+	endPoint := "https://api.us-south.assistant.watson.cloud.ibm.com"
 	pathSegments := []string{"v1/workspaces", "message"}
 	pathParameters := []string{"xxxxx"}
 	request := setup()
-	want := "https://gateway.watsonplatform.net/assistant/api/v1/workspaces/xxxxx/message"
+	want := "https://api.us-south.assistant.watson.cloud.ibm.com/v1/workspaces/xxxxx/message"
 	_, err := request.ConstructHTTPURL(endPoint, pathSegments, pathParameters)
 	assert.Nil(t, err)
 	assert.Equal(t, want, request.URL.String(), "Invalid construction of url")
 }
 
 func TestConstructHTTPURLWithNoPathParam(t *testing.T) {
-	endPoint := "https://gateway.watsonplatform.net/assistant/api"
+	endPoint := "https://api.us-south.assistant.watson.cloud.ibm.com"
 	pathSegments := []string{"v1/workspaces"}
 	request := setup()
-	want := "https://gateway.watsonplatform.net/assistant/api/v1/workspaces"
+	want := "https://api.us-south.assistant.watson.cloud.ibm.com/v1/workspaces"
 	_, err := request.ConstructHTTPURL(endPoint, pathSegments, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, want, request.URL.String(), "Invalid construction of url")
 }
 
 func TestConstructHTTPURLWithEmptyPathSegments(t *testing.T) {
-	endPoint := "https://gateway.watsonplatform.net/assistant/api"
+	endPoint := "https://api.us-south.assistant.watson.cloud.ibm.com"
 	pathSegments := []string{"v1/workspaces", "", "segment", ""}
 	pathParameters := []string{"param1", "param2", "param3", "param4"}
 	request := setup()
-	want := "https://gateway.watsonplatform.net/assistant/api/v1/workspaces/param1/param2/segment/param3/param4"
+	want := "https://api.us-south.assistant.watson.cloud.ibm.com/v1/workspaces/param1/param2/segment/param3/param4"
 	_, err := request.ConstructHTTPURL(endPoint, pathSegments, pathParameters)
 	assert.Nil(t, err)
 	assert.Equal(t, want, request.URL.String(), "Invalid construction of url")
 }
 
 func TestConstructHTTPURLWithEmptyPathParam(t *testing.T) {
-	endPoint := "https://gateway.watsonplatform.net/assistant/api"
+	endPoint := "https://api.us-south.assistant.watson.cloud.ibm.com"
 	pathSegments := []string{"v1/workspaces", "segment"}
 	pathParameters := []string{""}
 	request := setup()
@@ -575,10 +575,10 @@ func TestBuildWithMultipartFormWithRepeatedKeys(t *testing.T) {
 }
 
 func TestBuild(t *testing.T) {
-	endPoint := "https://gateway.watsonplatform.net/assistant/api"
+	endPoint := "https://api.us-south.assistant.watson.cloud.ibm.com"
 	pathSegments := []string{"v1/workspaces", "message"}
 	pathParameters := []string{"xxxxx"}
-	wantURL := "https://gateway.watsonplatform.net/assistant/api/xxxxx/v1/workspaces?Version=2018-22-09"
+	wantURL := "https://api.us-south.assistant.watson.cloud.ibm.com/xxxxx/v1/workspaces?Version=2018-22-09"
 
 	testStructure := &TestStructure{
 		Name: "wonder woman",

--- a/v4/resources/ibm-credentials.env
+++ b/v4/resources/ibm-credentials.env
@@ -18,9 +18,9 @@ MY_SERVICE3_PASSWORD=password1
 MY_SERVICE4_APIKEY=5678efgh
 MY_SERVICE4_USERNAME=test
 MY_SERVICE4_PASSWORD=pwd
-MY_SERVICE4_URL=https://gateway-s.watsonplatform.net/watson/api
+MY_SERVICE4_URL=https://api.us-south.assistant.watson.cloud.ibm.com
 #
 MY_SERVICE5_AUTH_TYPE=bearerToken
 MY_SERVICE5_USERNAME=test
 MY_SERVICE5_PASSWORD=pwd
-MY_SERVICE5_URL=https://gateway-s.watsonplatform.net/watson/api
+MY_SERVICE5_URL=https://api.us-south.assistant.watson.cloud.ibm.com


### PR DESCRIPTION
Watson gateway urls are being deprecated and will cease to function after 12 Feb 2021. This pull request updates the watsonplatform.net urls to the corresponding onecloud urls.