### PR TITLE
feat: support username/apikey use-case in CloudPakForDataAuthenticator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ credentials.txt
 *.coverprofile
 node_modules/
 .project
-.env
+*.env
 
 # ignore vendor/
 vendor/

--- a/Authentication.md
+++ b/Authentication.md
@@ -35,7 +35,7 @@ each outbound request in the `Authorization` header in the form:
 ### Programming example
 ```go
 import {
-    "github.com/IBM/go-sdk-core/core"
+    "github.com/IBM/go-sdk-core/v4/core"
     "<appropriate-git-repo-url>/exampleservicev1"
 }
 ...
@@ -65,7 +65,7 @@ export EXAMPLE_SERVICE_PASSWORD=mypassword
 Application code:
 ```go
 import {
-    "github.com/IBM/go-sdk-core/core"
+    "github.com/IBM/go-sdk-core/v4/core"
     "<appropriate-git-repo-url>/exampleservicev1"
 }
 ...
@@ -94,7 +94,7 @@ each outbound request in the `Authorization` header in the form:
 ### Programming example
 ```go
 import {
-    "github.com/IBM/go-sdk-core/core"
+    "github.com/IBM/go-sdk-core/v4/core"
     "<appropriate-git-repo-url>/exampleservicev1"
 }
 ...
@@ -127,7 +127,7 @@ export EXAMPLE_SERVICE_BEARER_TOKEN=<the bearer token value>
 Application code:
 ```go
 import {
-    "github.com/IBM/go-sdk-core/core"
+    "github.com/IBM/go-sdk-core/v4/core"
     "<appropriate-git-repo-url>/exampleservicev1"
 }
 ...
@@ -181,7 +181,7 @@ by the user, a suitable default Client will be constructed.
 ### Programming example
 ```go
 import {
-    "github.com/IBM/go-sdk-core/core"
+    "github.com/IBM/go-sdk-core/v4/core"
     "<appropriate-git-repo-url>/exampleservicev1"
 }
 ...
@@ -209,7 +209,7 @@ export EXAMPLE_SERVICE_APIKEY=myapikey
 Application code:
 ```go
 import {
-    "github.com/IBM/go-sdk-core/core"
+    "github.com/IBM/go-sdk-core/v4/core"
     "<appropriate-git-repo-url>/exampleservicev1"
 }
 ...
@@ -228,7 +228,8 @@ service := exampleservicev1.NewExampleServiceV1(options)
 ```
 
 ##  Cloud Pak for Data
-The `CloudPakForDataAuthenticator` will accept user-supplied username and password values, and will 
+The `CloudPakForDataAuthenticator` will accept a user-supplied username value, along with either a
+password or apikey, and will 
 perform the necessary interactions with the Cloud Pak for Data token service to obtain a suitable
 bearer token.  The authenticator will also obtain a new bearer token when the current token expires.
 The bearer token is then added to each outbound request in the `Authorization` header in the
@@ -238,8 +239,12 @@ form:
 ```
 ### Properties
 - Username: (required) the username used to obtain a bearer token.
-- Password: (required) the password used to obtain a bearer token.
-- URL: (required) The URL representing the Cloud Pak for Data token service endpoint.
+- Password: (required if APIKey is not specified) the user's password used to obtain a bearer token.
+Exactly one of Password or APIKey should be specified.
+- APIKey: (required if Password is not specified) the user's apikey used to obtain a bearer token.
+Exactly one of Password or APIKey should be specified.
+- URL: (required) The URL representing the Cloud Pak for Data token service endpoint's base URL string.
+This value should not include the `/v1/authorize` path portion.
 - DisableSSLVerification: (optional) A flag that indicates whether verificaton of the server's SSL 
 certificate should be disabled or not. The default value is `false`.
 - Headers: (optional) A set of key/value pairs that will be sent as HTTP headers in requests
@@ -249,20 +254,27 @@ by the user, a suitable default Client will be constructed.
 ### Programming example
 ```go
 import {
-    "github.com/IBM/go-sdk-core/core"
+    "github.com/IBM/go-sdk-core/v4/core"
     "<appropriate-git-repo-url>/exampleservicev1"
 }
 ...
-// Create the authenticator.
-authenticator := &core.CloudPakForDataAuthenticator{
+// Create the authenticator using username/password.
+authenticator1 := &core.CloudPakForDataAuthenticator{
     Username: "myuser",
     Password: "mypassword",
     URL: "https://mycp4dhost.com/",
 }
 
-// Create the service options struct.
+// Alternatively, create the authenticator using username/apikey.
+authenticator2 := &core.CloudPakForDataAuthenticator{
+    Username: "myuser",
+    APIKey: "myapikey",
+    URL: "https://mycp4dhost.com/",
+}
+
+// Create the service options struct using one of the authenticators above.
 options := &exampleservicev1.ExampleServiceV1Options{
-    Authenticator: authenticator,
+    Authenticator: authenticator1,
 }
 
 // Construct the service instance.
@@ -273,20 +285,27 @@ service := exampleservicev1.NewExampleServiceV1(options)
 ### Configuration example
 External configuration:
 ```
-export EXAMPLE_SERVICE_AUTH_TYPE=cp4d
-export EXAMPLE_SERVICE_USERNAME=myuser
-export EXAMPLE_SERVICE_PASSWORD=mypassword
-export EXAMPLE_SERVICE_URL=https://mycp4dhost.com/
+# Configure "example_service1" with username/password.
+export EXAMPLE_SERVICE1_AUTH_TYPE=cp4d
+export EXAMPLE_SERVICE1_USERNAME=myuser
+export EXAMPLE_SERVICE1_PASSWORD=mypassword
+export EXAMPLE_SERVICE1_URL=https://mycp4dhost.com/
+
+# Configure "example_service2" with username/apikey.
+export EXAMPLE_SERVICE2_AUTH_TYPE=cp4d
+export EXAMPLE_SERVICE2_USERNAME=myuser
+export EXAMPLE_SERVICE2_APIKEY=myapikey
+export EXAMPLE_SERVICE2_URL=https://mycp4dhost.com/
 ```
 Application code:
 ```go
 import {
-    "github.com/IBM/go-sdk-core/core"
+    "github.com/IBM/go-sdk-core/v4/core"
     "<appropriate-git-repo-url>/exampleservicev1"
 }
 ...
-// Construct the authenticator from external configuration information for service "example_service".
-authenticator := &core.GetAuthenticatorFromEnvironment("example_service")
+// Construct the authenticator from external configuration information for service "example_service1".
+authenticator := &core.GetAuthenticatorFromEnvironment("example_service1")
 
 // Create the service options struct.
 options := &exampleservicev1.ExampleServiceV1Options{
@@ -305,7 +324,7 @@ None
 ### Programming example
 ```go
 import {
-    "github.com/IBM/go-sdk-core/core"
+    "github.com/IBM/go-sdk-core/v4/core"
     "<appropriate-git-repo-url>/exampleservicev1"
 }
 ...
@@ -330,7 +349,7 @@ export EXAMPLE_SERVICE_AUTH_TYPE=noauth
 Application code:
 ```go
 import {
-    "github.com/IBM/go-sdk-core/core"
+    "github.com/IBM/go-sdk-core/v4/core"
     "<appropriate-git-repo-url>/exampleservicev1"
 }
 ...

--- a/v4/core/base_service_test.go
+++ b/v4/core/base_service_test.go
@@ -2,7 +2,7 @@
 
 package core
 
-// (C) Copyright IBM Corp. 2019, 2020.
+// (C) Copyright IBM Corp. 2019, 2021.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ func TestRequestGoodResponseJSON(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("POST")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	req, _ := builder.Build()
 
@@ -114,7 +114,7 @@ func TestRequestGoodResponseJSONStream(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("POST")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	req, _ := builder.Build()
 
@@ -167,7 +167,7 @@ func TestRequestGoodResponseJSONExtraFields(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	req, _ := builder.Build()
 
@@ -198,7 +198,7 @@ func TestRequestGoodResponseStream(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	req, _ := builder.Build()
 
@@ -238,7 +238,7 @@ func TestRequestGoodResponseText(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	req, _ := builder.Build()
 
@@ -275,7 +275,7 @@ func TestRequestGoodResponseString(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	req, _ := builder.Build()
 
@@ -317,7 +317,7 @@ func TestRequestGoodResponseNonJSONNoContentType(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	req, _ := builder.Build()
 
@@ -356,7 +356,7 @@ func TestRequestGoodResponseJSONDeserFailure(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	req, _ := builder.Build()
 
@@ -386,7 +386,7 @@ func TestRequestGoodResponseNoBody(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	req, _ := builder.Build()
 
@@ -449,7 +449,7 @@ var jsonErrorResponse string = `{
 }`
 
 // Example of a non-JSON error response body.
-var nonJsonErrorResponse string = `This is a non-JSON error response body.`
+var nonJSONErrorResponse string = `This is a non-JSON error response body.`
 
 // Test an error response with a JSON response body.
 func TestRequestErrorResponseJSON(t *testing.T) {
@@ -461,7 +461,7 @@ func TestRequestErrorResponseJSON(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	builder.AddHeader("Content-Type", "Application/json").
 		AddQuery("Version", "2018-22-09")
@@ -497,7 +497,7 @@ func TestRequestErrorResponseJSONDeserError(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	builder.AddHeader("Content-Type", "Application/json").
 		AddQuery("Version", "2018-22-09")
@@ -524,12 +524,12 @@ func TestRequestErrorResponseNotJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-type", "text/plain")
 		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprint(w, nonJsonErrorResponse)
+		fmt.Fprint(w, nonJSONErrorResponse)
 	}))
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	builder.AddHeader("Content-Type", "Application/json").
 		AddQuery("Version", "2018-22-09")
@@ -549,7 +549,7 @@ func TestRequestErrorResponseNotJSON(t *testing.T) {
 	assert.Nil(t, response.Result)
 	assert.NotNil(t, response.RawResult)
 	s := string(response.RawResult)
-	assert.Equal(t, nonJsonErrorResponse, s)
+	assert.Equal(t, nonJSONErrorResponse, s)
 	assert.Equal(t, http.StatusText(http.StatusBadRequest), err.Error())
 }
 
@@ -561,7 +561,7 @@ func TestRequestErrorResponseNoBody(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	builder.AddHeader("Content-Type", "Application/json").
 		AddQuery("Version", "2018-22-09")
@@ -608,7 +608,7 @@ func TestRequestForDefaultUserAgent(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	builder.AddHeader("Content-Type", "Application/json").
 		AddQuery("Version", "2018-22-09")
@@ -634,7 +634,7 @@ func TestRequestForProvidedUserAgent(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	builder.AddHeader("Content-Type", "Application/json").
 		AddQuery("Version", "2018-22-09")
@@ -700,7 +700,7 @@ func TestRequestBasicAuth1(t *testing.T) {
 	assert.Equal(t, AUTHTYPE_BASIC, service.Options.Authenticator.AuthenticationType())
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	builder.AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
@@ -729,7 +729,7 @@ func TestRequestBasicAuth2(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	builder.AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
@@ -782,7 +782,7 @@ func TestRequestNoAuth1(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	builder.AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
@@ -811,7 +811,7 @@ func TestRequestNoAuth2(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	builder.AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
@@ -863,7 +863,7 @@ func TestRequestIAMAuth(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	builder.AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
@@ -904,7 +904,7 @@ func TestRequestIAMFailure(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	builder.AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
@@ -941,7 +941,7 @@ func TestRequestIAMFailureRetryAfter(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	builder.AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
@@ -994,7 +994,7 @@ func TestRequestIAMWithIdSecret(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	builder.AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
@@ -1055,33 +1055,25 @@ func TestRequestIAMNoApiKey(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+const (
+	// #nosec
+	cp4dString = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3R1c2VyIiwicm9sZSI6IlVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhY2Nlc3NfY2F0YWxvZyIsImNhbl9wcm92aXNpb24iLCJzaWduX2luX29ubHkiXSwiZ3JvdXBzIjpbMTAwMDBdLCJzdWIiOiJ0ZXN0dXNlciIsImlzcyI6IktOT1hTU08iLCJhdWQiOiJEU1giLCJ1aWQiOiIxMDAwMzMxMDAzIiwiYXV0aGVudGljYXRvciI6ImRlZmF1bHQiLCJpYXQiOjE2MTA0ODg2NzAsImV4cCI6MTYxMDUzMTgzNH0.K5Mqsv3E9MMXotuhUWbAcTUe41thzSaiFOolnvNxIVPwApSJr_VappL8GTR6BgwPz5gB4MX9w8mVsh0vX8g5naRHWryKNxloHiWiOzCpI982EACkb7Lvdpo5vq_wOANM4OW5Q7cyWXMrqQMz1wF-4-1EyYHBbAKWWGmSQZ6iW7wgMxoeP027vGTD96IVFhgOrvX1hEBDMZ0S9gfKU0bthUMEDKoWONcFuWlHQChhh7agjP2RS4d3Rcjx2oHtx_zuH5bEXxn9g4Dj2v9Bkn6aOFQivSGFUlaus_6opZ6x5aCPi6SXnO_xOY_f2XKU-DUg-yN5BeX7fXu35JQTGFcgwQ"
+)
+
 func TestRequestCP4DAuth(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		if strings.Contains(r.URL.String(), "preauth") {
-			fmt.Fprint(w, `{
-			"username":"hello",
-			"role":"user",
-			"permissions":[
-				"administrator",
-				"deployment_admin"
-			],
-			"sub":"hello",
-			"iss":"John",
-			"aud":"DSX",
-			"uid":"999",
-			"accessToken":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-			"_messageCode_":"success",
-			"message":"success"
-		}`)
+		if strings.HasSuffix(r.URL.String(), "/v1/authorize") {
+			fmt.Fprintf(w, `{"token":"%s","_messageCode_":"200","message":"success"}`, cp4dString)
 		} else {
-			assert.Equal(t, "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI", r.Header.Get("Authorization"))
+			expectedAuthHeader := fmt.Sprintf("Bearer %s", cp4dString)
+			assert.Equal(t, expectedAuthHeader, r.Header.Get("Authorization"))
 		}
 	}))
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	builder.AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
@@ -1112,7 +1104,7 @@ func TestRequestCP4DFail(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	builder.AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()
@@ -1150,7 +1142,7 @@ func TestRequestCp4dFailureRetryAfter(t *testing.T) {
 	defer server.Close()
 
 	builder := NewRequestBuilder("GET")
-	_, err := builder.ConstructHTTPURL(server.URL, nil, nil)
+	_, err := builder.ResolveRequestURL(server.URL, "", nil)
 	assert.Nil(t, err)
 	builder.AddQuery("Version", "2018-22-09")
 	req, _ := builder.Build()

--- a/v4/core/constants.go
+++ b/v4/core/constants.go
@@ -1,6 +1,6 @@
 package core
 
-// (C) Copyright IBM Corp. 2019.
+// (C) Copyright IBM Corp. 2019, 2021.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ const (
 	// Common error messages.
 	ERRORMSG_PROP_MISSING            = "The %s property is required but was not specified."
 	ERRORMSG_PROP_INVALID            = "The %s property is invalid. Please remove any surrounding {, }, or \" characters."
+	ERRORMSG_EXCLUSIVE_PROPS_ERROR   = "Exactly one of %s or %s must be specified."
 	ERRORMSG_NO_AUTHENTICATOR        = "Authentication information was not properly configured."
 	ERRORMSG_AUTHTYPE_UNKNOWN        = "Unrecognized authentication type: %s"
 	ERRORMSG_PROPS_MAP_NIL           = "The 'properties' map cannot be nil."
@@ -67,4 +68,5 @@ const (
 	ERRORMSG_CONVERT_SLICE           = "An error occurred while converting 'slice' to string slice"
 	ERRORMSG_CREATE_RETRYABLE_REQ    = "An error occurred while creating a retryable http Request: %s"
 	ERRORMSG_UNEXPECTED_STATUS_CODE  = "Unexpected HTTP status code %d (%s)"
+	ERRORMSG_UNMARSHAL_AUTH_RESPONSE = "error unmarshalling authentication response: %s"
 )

--- a/v4/core/cp4d_authenticator_test.go
+++ b/v4/core/cp4d_authenticator_test.go
@@ -2,7 +2,7 @@
 
 package core
 
-// (C) Copyright IBM Corp. 2019.
+// (C) Copyright IBM Corp. 2019, 2021.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,17 +17,59 @@ package core
 // limitations under the License.
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	assert "github.com/stretchr/testify/assert"
 )
 
-func TestCp4dConfigErrors(t *testing.T) {
+const (
+	// These access tokens were obtained by running curl to invoke the POST /v1/authorize against a CP4D environment.
+
+	// Username/password
+	// curl -k -X POST https://<host>/icp4d-api/v1/authorize -H 'Content-Type: application/json' \
+	//      -d '{"username": "testuser", "password": "<password>" }'
+	// #nosec
+	cp4dUsernamePwd1 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3R1c2VyIiwicm9sZSI6IlVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhY2Nlc3NfY2F0YWxvZyIsImNhbl9wcm92aXNpb24iLCJzaWduX2luX29ubHkiXSwiZ3JvdXBzIjpbMTAwMDBdLCJzdWIiOiJ0ZXN0dXNlciIsImlzcyI6IktOT1hTU08iLCJhdWQiOiJEU1giLCJ1aWQiOiIxMDAwMzMxMDAzIiwiYXV0aGVudGljYXRvciI6ImRlZmF1bHQiLCJpYXQiOjE2MTA0ODg2NzAsImV4cCI6MTYxMDUzMTgzNH0.K5Mqsv3E9MMXotuhUWbAcTUe41thzSaiFOolnvNxIVPwApSJr_VappL8GTR6BgwPz5gB4MX9w8mVsh0vX8g5naRHWryKNxloHiWiOzCpI982EACkb7Lvdpo5vq_wOANM4OW5Q7cyWXMrqQMz1wF-4-1EyYHBbAKWWGmSQZ6iW7wgMxoeP027vGTD96IVFhgOrvX1hEBDMZ0S9gfKU0bthUMEDKoWONcFuWlHQChhh7agjP2RS4d3Rcjx2oHtx_zuH5bEXxn9g4Dj2v9Bkn6aOFQivSGFUlaus_6opZ6x5aCPi6SXnO_xOY_f2XKU-DUg-yN5BeX7fXu35JQTGFcgwQ"
+	// #nosec
+	cp4dUsernamePwd2 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3R1c2VyIiwicm9sZSI6IlVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhY2Nlc3NfY2F0YWxvZyIsImNhbl9wcm92aXNpb24iLCJzaWduX2luX29ubHkiXSwiZ3JvdXBzIjpbMTAwMDBdLCJzdWIiOiJ0ZXN0dXNlciIsImlzcyI6IktOT1hTU08iLCJhdWQiOiJEU1giLCJ1aWQiOiIxMDAwMzMxMDAzIiwiYXV0aGVudGljYXRvciI6ImRlZmF1bHQiLCJpYXQiOjE2MTA0ODg2NzcsImV4cCI6MTYxMDUzMTg0MX0.NZiTLN_D5ayzHNonVdba-B_ej7mugBsDgEUa63KUtEOhXOJ_E4ZOlwVKKhd0PUvn0ZPabfaD4-hmekDC6-TgnCn3aAkwwfM7hAaY9XvFwECzRC2yg08dgenc8TiOHhQ_7tYnpJxNbhyN-3guiMl3YgB46rbPSWbpgbd0z8uzZwVpSOY3AfbgLSyiDWN9dqOELeUxI1tUubMVWspbflrXhpS-p61UGsO3uqBSpMPw6fG19kSdaKdRaGx-Wg2uiTAZqAVrGNAGIVX-X_sx2EJcjYYK8_1n9O5bHSPQ3HonOtgYvqD2FbbBdiX9H7TblucYr-mMTjktuWXDYprvqRHg2g"
+
+	// Username/apikey
+	// curl -k -X POST https://<host>/icp4d-api/v1/authorize -H 'Content-Type: application/json' \
+	//      -d '{"username": "testuser", "api_key": "<apikey>" }'
+	// #nosec
+	cp4dUsernameApikey1 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3R1c2VyIiwicm9sZSI6IlVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhY2Nlc3NfY2F0YWxvZyIsImNhbl9wcm92aXNpb24iLCJzaWduX2luX29ubHkiXSwiZ3JvdXBzIjpbMTAwMDBdLCJzdWIiOiJ0ZXN0dXNlciIsImlzcyI6IktOT1hTU08iLCJhdWQiOiJEU1giLCJ1aWQiOiIxMDAwMzMxMDAzIiwiYXV0aGVudGljYXRvciI6ImRlZmF1bHQiLCJpYXQiOjE2MTA1NDgyNDgsImV4cCI6MTYxMDU5MTQxMn0.I8MgxrapKRt0nOn0F41NtLHQ5HGmInZNaJIWcNwyBgLWI5YY_98kpKLecN5d9Ll9g0_lapAFs_b8xpTya0Lvnp2Q81SloRFpDhAMUVHVWq46g2dvZd1JpoFB8NHwrkz2qE_JUHBIonJmQusy8vMm1m1CPy0pE6fTYH1d5EJG2vLo6f2eFiDizLfGxb0ym9lUOkK6dgNZw2T32N8IoSYNan6BQU25Jai6llWRLwZda7R521EPEw2AtPDsd95AxoTd8f4pptxfkL2uXpT35wRguap_09sRlvDTR18Ghs-GbtCh3Do-8OPGEFYKvJkSHNpiXPw8pvHEe5jCGl3l3F5vXQ"
+	// #nosec
+	cp4dUsernameApikey2 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3R1c2VyIiwicm9sZSI6IlVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhY2Nlc3NfY2F0YWxvZyIsImNhbl9wcm92aXNpb24iLCJzaWduX2luX29ubHkiXSwiZ3JvdXBzIjpbMTAwMDBdLCJzdWIiOiJ0ZXN0dXNlciIsImlzcyI6IktOT1hTU08iLCJhdWQiOiJEU1giLCJ1aWQiOiIxMDAwMzMxMDAzIiwiYXV0aGVudGljYXRvciI6ImRlZmF1bHQiLCJpYXQiOjE2MTA1NDg5ODgsImV4cCI6MTYxMDU5MjE1Mn0.NQcEUveRFm87ZZhh6v74kqHNC-MC_frLg3dQxUk5gcviN32DjSeg6THDIpQoi85I1tkEMuuOYyZejrh4f_AsEteNVRXOdrmprB35VqDBdIlH1jFUl2DIVQXR93CKr_Flh31RPFDd43Ut9ZHraZaUWmnzlJxv8170t4-5f2eJASG2EqDZXqxqu9zEpHBvBefwkgKClWcFF9VcfJJCqRkbBNhNZhRQu5sH62VUiQqS-CStMsYn8NCgvj5WMqgcXMMFSX3B6poPvhhk-uPtUAiK50iPnEbQlTZNajLAAd-whn8TV2LFOrfKCfO-USWy-lbG8F-koM0tfAi0N4WzySqErg"
+)
+
+// getJSONRequestBody unmarshals the body contained in 'req' into 'result'
+func getJSONRequestBody(req *http.Request, result interface{}) error {
+	defer req.Body.Close()
+	buf, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return err
+	}
+
+	// Unmarshal the byte array as JSON.
+	err = json.Unmarshal(buf, result)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestCp4dConfigErrorsPW1(t *testing.T) {
 	var err error
+
+	// Tests using the original ctor.
 
 	// Missing URL.
 	_, err = NewCloudPakForDataAuthenticator("", "mookie", "betts", false, nil)
@@ -42,14 +84,50 @@ func TestCp4dConfigErrors(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestCp4dAuthenticateFail(t *testing.T) {
+func TestCp4dConfigErrorsPW2(t *testing.T) {
+	var err error
+
+	// Tests using the new "UsingPassword" ctor.
+
+	// Missing URL.
+	_, err = NewCloudPakForDataAuthenticatorUsingPassword("", "mookie", "betts", false, nil)
+	assert.NotNil(t, err)
+
+	// Missing Username.
+	_, err = NewCloudPakForDataAuthenticatorUsingPassword("cp4d-url", "", "betts", false, nil)
+	assert.NotNil(t, err)
+
+	// Missing Password.
+	_, err = NewCloudPakForDataAuthenticatorUsingPassword("cp4d-url", "mookie", "", false, nil)
+	assert.NotNil(t, err)
+}
+
+func TestCp4dConfigErrorsAPIKey(t *testing.T) {
+	var err error
+
+	// Tests using the new "UsingAPIKey" ctor.
+
+	// Missing URL.
+	_, err = NewCloudPakForDataAuthenticatorUsingAPIKey("", "mookie", "betts", false, nil)
+	assert.NotNil(t, err)
+
+	// Missing Username.
+	_, err = NewCloudPakForDataAuthenticatorUsingAPIKey("cp4d-url", "", "betts", false, nil)
+	assert.NotNil(t, err)
+
+	// Missing APIKey.
+	_, err = NewCloudPakForDataAuthenticatorUsingAPIKey("cp4d-url", "mookie", "", false, nil)
+	assert.NotNil(t, err)
+}
+
+func TestCp4dAuthenticateFailure(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 		_, _ = w.Write([]byte("Sorry you are not authorized"))
 	}))
 	defer server.Close()
 
-	authenticator, err := NewCloudPakForDataAuthenticator(server.URL, "mookie", "betts", false, nil)
+	authenticator, err := NewCloudPakForDataAuthenticatorUsingPassword(server.URL, "mookie", "betts", false, nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, authenticator)
 	assert.Equal(t, authenticator.AuthenticationType(), AUTHTYPE_CP4D)
@@ -73,57 +151,33 @@ func TestCp4dAuthenticateFail(t *testing.T) {
 	assert.Equal(t, err.Error(), authErr.Error())
 }
 
-func TestCp4dGetTokenSuccess(t *testing.T) {
+func verifyAuthRequest(t *testing.T, r *http.Request,
+	expectedUsername string, expectedPassword string, expectedApikey string) {
+
+	assert.True(t, strings.HasSuffix(r.URL.String(), "/v1/authorize"))
+	assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+	var requestBody *cp4dRequestBody
+	err := getJSONRequestBody(r, &requestBody)
+	assert.Nil(t, err)
+	assert.NotNil(t, requestBody)
+	assert.Equal(t, expectedUsername, requestBody.Username)
+	assert.Equal(t, expectedPassword, requestBody.Password)
+	assert.Equal(t, expectedApikey, requestBody.APIKey)
+}
+
+func TestCp4dGetTokenSuccessPW(t *testing.T) {
 	firstCall := true
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		verifyAuthRequest(t, r, "mookie", "betts", "")
+
 		w.WriteHeader(http.StatusOK)
+
 		if firstCall {
-			fmt.Fprintf(w, `{
-				"username":"hello",
-				"role":"user",
-				"permissions":[  
-					"administrator",
-					"deployment_admin"
-				],
-				"sub":"hello",
-				"iss":"John",
-				"aud":"DSX",
-				"uid":"999",
-				"accessToken":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-				"_messageCode_":"success",
-				"message":"success"
-			}`)
+			fmt.Fprintf(w, `{ "_messageCode_":"200", "message":"success", "token":"%s"}`, cp4dUsernamePwd1)
 			firstCall = false
-			username, password, ok := r.BasicAuth()
-			assert.Equal(t, true, ok)
-			assert.Equal(t, "mookie", username)
-			assert.Equal(t, "betts", password)
 		} else {
-			fmt.Fprintf(w, `{
-				"username": "admin",
-  				"role": "Admin",
-  				"permissions": [
-    				"administrator",
-    				"manage_catalog",
-    				"access_catalog",
-    				"manage_policies",
-    				"access_policies",
-    				"virtualize_transform",
-    				"can_provision",
-    				"deployment_admin"
-  				],
-  				"sub": "admin",
-  				"iss": "test",
-  				"aud": "DSX",
-  				"uid": "999",
-  				"accessToken": "3yJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-  				"_messageCode_": "success",
-  				"message": "success"
-			}`)
-			username, password, ok := r.BasicAuth()
-			assert.Equal(t, true, ok)
-			assert.Equal(t, "mookie", username)
-			assert.Equal(t, "betts", password)
+			fmt.Fprintf(w, `{ "_messageCode_":"200", "message":"success", "token":"%s"}`, cp4dUsernamePwd2)
 		}
 	}))
 	defer server.Close()
@@ -135,82 +189,75 @@ func TestCp4dGetTokenSuccess(t *testing.T) {
 	// Force the first fetch and verify we got the correct access token back
 	accessToken, err := authenticator.getToken()
 	assert.Nil(t, err)
-	assert.Equal(t, "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-		accessToken)
+	assert.Equal(t, cp4dUsernamePwd1, accessToken)
 
 	// Force an expiration and verify we get back the second access token.
 	authenticator.tokenData = nil
 	accessToken, err = authenticator.getToken()
 	assert.Nil(t, err)
 	assert.NotNil(t, authenticator.tokenData)
-	assert.Equal(t, "3yJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-		accessToken)
+	assert.Equal(t, cp4dUsernamePwd2, accessToken)
 }
 
-func TestCp4dGetCachedToken(t *testing.T) {
+func TestCp4dGetTokenSuccessAPIKey(t *testing.T) {
 	firstCall := true
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		verifyAuthRequest(t, r, "mookie", "", "my_apikey")
+
 		w.WriteHeader(http.StatusOK)
+
 		if firstCall {
-			fmt.Fprintf(w, `{
-				"username":"hello",
-				"role":"user",
-				"permissions":[  
-					"administrator",
-					"deployment_admin"
-				],
-				"sub":"hello",
-				"iss":"John",
-				"aud":"DSX",
-				"uid":"999",
-				"accessToken":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-				"_messageCode_":"success",
-				"message":"success"
-			}`)
+			fmt.Fprintf(w, `{ "_messageCode_":"200", "message":"success", "token":"%s"}`, cp4dUsernameApikey1)
 			firstCall = false
-			username, password, ok := r.BasicAuth()
-			assert.Equal(t, true, ok)
-			assert.Equal(t, "john", username)
-			assert.Equal(t, "snow", password)
 		} else {
-			fmt.Fprintf(w, `{
-				"username": "admin",
-  				"role": "Admin",
-  				"permissions": [
-    				"administrator",
-    				"manage_catalog",
-    				"access_catalog",
-    				"manage_policies",
-    				"access_policies",
-    				"virtualize_transform",
-    				"can_provision",
-    				"deployment_admin"
-  				],
-  				"sub": "admin",
-  				"iss": "test",
-  				"aud": "DSX",
-  				"uid": "999",
-  				"accessToken": "3yJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-  				"_messageCode_": "success",
-  				"message": "success"
-			}`)
-			username, password, ok := r.BasicAuth()
-			assert.Equal(t, true, ok)
-			assert.Equal(t, "john", username)
-			assert.Equal(t, "snow", password)
+			fmt.Fprintf(w, `{ "_messageCode_":"200", "message":"success", "token":"%s"}`, cp4dUsernameApikey2)
 		}
 	}))
 	defer server.Close()
 
-	authenticator, err := NewCloudPakForDataAuthenticator(server.URL, "john", "snow", false, nil)
+	authenticator, err := NewCloudPakForDataAuthenticatorUsingAPIKey(server.URL, "mookie", "my_apikey", false, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, authenticator)
+
+	// Force the first fetch and verify we got the correct access token back
+	accessToken, err := authenticator.getToken()
+	assert.Nil(t, err)
+	assert.Equal(t, cp4dUsernameApikey1, accessToken)
+
+	// Force an expiration and verify we get back the second access token.
+	authenticator.tokenData = nil
+	accessToken, err = authenticator.getToken()
+	assert.Nil(t, err)
+	assert.NotNil(t, authenticator.tokenData)
+	assert.Equal(t, cp4dUsernameApikey2, accessToken)
+}
+
+func TestCp4dGetCachedTokenSuccessPW(t *testing.T) {
+	firstCall := true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		verifyAuthRequest(t, r, "john", "snow", "")
+
+		w.WriteHeader(http.StatusOK)
+
+		if firstCall {
+			fmt.Fprintf(w, `{ "_messageCode_":"200", "message":"success", "token":"%s"}`, cp4dUsernamePwd1)
+			firstCall = false
+		} else {
+			fmt.Fprintf(w, `{ "_messageCode_":"200", "message":"success", "token":"%s"}`, cp4dUsernamePwd2)
+		}
+	}))
+	defer server.Close()
+
+	authenticator, err := NewCloudPakForDataAuthenticatorUsingPassword(server.URL, "john", "snow", false, nil)
 	assert.Nil(t, err)
 	assert.Nil(t, authenticator.tokenData)
 
 	// Force the first fetch and verify we got the first access token.
 	token, err := authenticator.getToken()
 	assert.Nil(t, err)
-	assert.Equal(t, "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-		token)
+	assert.Equal(t, cp4dUsernamePwd1, token)
 	assert.NotNil(t, authenticator.tokenData)
 
 	// To mock the cache, set the expiration on the existing token to be somewhere in the valid timeframe
@@ -219,242 +266,241 @@ func TestCp4dGetCachedToken(t *testing.T) {
 	// Subsequent fetch should still return first access token.
 	token, err = authenticator.getToken()
 	assert.Nil(t, err)
-	assert.Equal(t, "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-		token)
+	assert.Equal(t, cp4dUsernamePwd1, token)
 	assert.NotNil(t, authenticator.tokenData)
 }
 
-func TestCp4dBackgroundTokenRefresh(t *testing.T) {
+func TestCp4dGetCachedTokenAPIKey(t *testing.T) {
 	firstCall := true
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		verifyAuthRequest(t, r, "john", "", "King of the North")
+
 		w.WriteHeader(http.StatusOK)
+
 		if firstCall {
-			fmt.Fprintf(w, `{
-				"username":"hello",
-				"role":"user",
-				"permissions":[  
-					"administrator",
-					"deployment_admin"
-				],
-				"sub":"hello",
-				"iss":"John",
-				"aud":"DSX",
-				"uid":"999",
-				"accessToken":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-				"_messageCode_":"success",
-				"message":"success"
-			}`)
+			fmt.Fprintf(w, `{ "_messageCode_":"200", "message":"success", "token":"%s"}`, cp4dUsernameApikey1)
 			firstCall = false
-			username, password, ok := r.BasicAuth()
-			assert.Equal(t, true, ok)
-			assert.Equal(t, "john", username)
-			assert.Equal(t, "snow", password)
 		} else {
-			fmt.Fprintf(w, `{
-				"username": "admin",
-  				"role": "Admin",
-  				"permissions": [
-    				"administrator",
-    				"manage_catalog",
-    				"access_catalog",
-    				"manage_policies",
-    				"access_policies",
-    				"virtualize_transform",
-    				"can_provision",
-    				"deployment_admin"
-  				],
-  				"sub": "admin",
-  				"iss": "test",
-  				"aud": "DSX",
-  				"uid": "999",
-  				"accessToken": "3yJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-  				"_messageCode_": "success",
-  				"message": "success"
-			}`)
-			username, password, ok := r.BasicAuth()
-			assert.Equal(t, true, ok)
-			assert.Equal(t, "john", username)
-			assert.Equal(t, "snow", password)
+			fmt.Fprintf(w, `{ "_messageCode_":"200", "message":"success", "token":"%s"}`, cp4dUsernameApikey2)
 		}
 	}))
 	defer server.Close()
 
-	authenticator, err := NewCloudPakForDataAuthenticator(server.URL, "john", "snow", false, nil)
+	authenticator, err := NewCloudPakForDataAuthenticatorUsingAPIKey(server.URL, "john", "King of the North", false, nil)
 	assert.Nil(t, err)
 	assert.Nil(t, authenticator.tokenData)
 
 	// Force the first fetch and verify we got the first access token.
 	token, err := authenticator.getToken()
 	assert.Nil(t, err)
-	assert.Equal(t, "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-		token)
+	assert.Equal(t, cp4dUsernameApikey1, token)
+	assert.NotNil(t, authenticator.tokenData)
+
+	// To mock the cache, set the expiration on the existing token to be somewhere in the valid timeframe
+	authenticator.tokenData.Expiration = GetCurrentTime() + 9999
+
+	// Subsequent fetch should still return first access token.
+	token, err = authenticator.getToken()
+	assert.Nil(t, err)
+	assert.Equal(t, cp4dUsernameApikey1, token)
+	assert.NotNil(t, authenticator.tokenData)
+}
+
+func TestCp4dGetTokenAuthFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("Forbidden!"))
+	}))
+	defer server.Close()
+
+	authenticator := &CloudPakForDataAuthenticator{
+		URL:      server.URL,
+		Username: "john",
+		Password: "snow",
+	}
+
+	_, err := authenticator.getToken()
+	assert.NotNil(t, err)
+	assert.Equal(t, "Forbidden!", err.Error())
+
+	// We expect an AuthenticationError to be returned, so cast the returned error
+	authError, ok := err.(*AuthenticationError)
+	assert.True(t, ok)
+	assert.NotNil(t, authError)
+	assert.NotNil(t, authError.Error())
+	assert.NotNil(t, authError.Response)
+	rawResult := authError.Response.GetRawResult()
+	assert.NotNil(t, rawResult)
+	assert.Equal(t, []byte("Forbidden!"), rawResult)
+
+	statusCode := authError.Response.GetStatusCode()
+	assert.Equal(t, "Forbidden!", authError.Error())
+	assert.Equal(t, http.StatusForbidden, statusCode)
+}
+
+func TestCp4dGetTokenDeserFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Bad access token response!"))
+	}))
+	defer server.Close()
+
+	authenticator := &CloudPakForDataAuthenticator{
+		URL:      server.URL,
+		Username: "john",
+		Password: "snow",
+	}
+
+	_, err := authenticator.getToken()
+	assert.NotNil(t, err)
+	assert.True(t, strings.HasPrefix(err.Error(), "error unmarshalling authentication response"))
+
+	// We expect something other than an AuthenticationError to be returned.
+	authError, ok := err.(*AuthenticationError)
+	assert.False(t, ok)
+	assert.Nil(t, authError)
+}
+
+func TestCp4dBackgroundTokenRefreshSuccess(t *testing.T) {
+	firstCall := true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		verifyAuthRequest(t, r, "john", "", "King of the North")
+
+		w.WriteHeader(http.StatusOK)
+
+		if firstCall {
+			fmt.Fprintf(w, `{ "_messageCode_":"200", "message":"success", "token":"%s"}`, cp4dUsernameApikey1)
+			firstCall = false
+		} else {
+			fmt.Fprintf(w, `{ "_messageCode_":"200", "message":"success", "token":"%s"}`, cp4dUsernameApikey2)
+		}
+	}))
+	defer server.Close()
+
+	authenticator, err := NewCloudPakForDataAuthenticatorUsingAPIKey(server.URL, "john", "King of the North", false, nil)
+	assert.Nil(t, err)
+	assert.Nil(t, authenticator.tokenData)
+
+	// Force the first fetch and verify we got the first access token.
+	token, err := authenticator.getToken()
+	assert.Nil(t, err)
+	assert.Equal(t, cp4dUsernameApikey1, token)
 	assert.NotNil(t, authenticator.tokenData)
 
 	// Now put the test in the "refresh window" where the token is not expired but still needs to be refreshed.
 	authenticator.tokenData.Expiration = GetCurrentTime() + 3600
 	authenticator.tokenData.RefreshTime = GetCurrentTime() - 720
+
 	// Authenticator should detect the need to refresh and request a new access token IN THE BACKGROUND when we call
 	// getToken() again. The immediate response should be the token which was already stored, since it's not yet
 	// expired.
 	token, err = authenticator.getToken()
 	assert.Nil(t, err)
-	assert.Equal(t, "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-		token)
+	assert.Equal(t, cp4dUsernameApikey1, token)
 	assert.NotNil(t, authenticator.tokenData)
-	// Wait for the background thread to finish
+
+	// Wait for the background thread to finish.
 	time.Sleep(5 * time.Second)
 	token, err = authenticator.getToken()
 	assert.Nil(t, err)
-	assert.Equal(t, "3yJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-		token)
+	assert.Equal(t, cp4dUsernameApikey2, token)
 	assert.NotNil(t, authenticator.tokenData)
-
 }
 
-func TestCp4dBackgroundTokenRefreshFailure(t *testing.T) {
+func TestCp4dBackgroundTokenRefreshAuthFailure(t *testing.T) {
 	firstCall := true
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
+
+		verifyAuthRequest(t, r, "john", "snow", "")
+
 		if firstCall {
-			fmt.Fprintf(w, `{
-				"username":"hello",
-				"role":"user",
-				"permissions":[  
-					"administrator",
-					"deployment_admin"
-				],
-				"sub":"hello",
-				"iss":"John",
-				"aud":"DSX",
-				"uid":"999",
-				"accessToken":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-				"_messageCode_":"success",
-				"message":"success"
-			}`)
+			t.Logf("Sending back 200!")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{ "_messageCode_":"200", "message":"success", "token":"%s"}`, cp4dUsernamePwd1)
 			firstCall = false
-			username, password, ok := r.BasicAuth()
-			assert.Equal(t, true, ok)
-			assert.Equal(t, "john", username)
-			assert.Equal(t, "snow", password)
 		} else {
-			_, _ = w.Write([]byte("Sorry you are forbidden"))
+			t.Logf("Sending back 403!")
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprintf(w, "Forbidden!")
 		}
 	}))
 	defer server.Close()
 
-	authenticator, err := NewCloudPakForDataAuthenticator(server.URL, "john", "snow", false, nil)
+	authenticator, err := NewCloudPakForDataAuthenticatorUsingPassword(server.URL, "john", "snow", false, nil)
 	assert.Nil(t, err)
 	assert.Nil(t, authenticator.tokenData)
 
 	// Force the first fetch and verify we got the first access token.
 	token, err := authenticator.getToken()
 	assert.Nil(t, err)
-	assert.Equal(t, "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-		token)
+	assert.Equal(t, cp4dUsernamePwd1, token)
 	assert.NotNil(t, authenticator.tokenData)
 
 	// Now put the test in the "refresh window" where the token is not expired but still needs to be refreshed.
 	authenticator.tokenData.Expiration = GetCurrentTime() + 3600
 	authenticator.tokenData.RefreshTime = GetCurrentTime() - 720
+
 	// Authenticator should detect the need to refresh and request a new access token IN THE BACKGROUND when we call
 	// getToken() again. The immediate response should be the token which was already stored, since it's not yet
 	// expired.
 	token, err = authenticator.getToken()
 	assert.Nil(t, err)
-	assert.Equal(t, "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-		token)
+	assert.Equal(t, cp4dUsernamePwd1, token)
 	assert.NotNil(t, authenticator.tokenData)
+
 	// Wait for the background thread to finish
 	time.Sleep(5 * time.Second)
 	_, err = authenticator.getToken()
 	assert.NotNil(t, err)
-	assert.Equal(t, "Error while trying to parse access token!", err.Error())
-	// We don't expect a AuthenticateError to be returned, so casting should fail
+	assert.Equal(t, "Forbidden!", err.Error())
+
+	// We expect an AuthenticationError to be returned, so casting should work.
 	_, ok := err.(*AuthenticationError)
-	assert.False(t, ok)
+	assert.True(t, ok)
 }
 
 func TestCp4dBackgroundTokenRefreshIdle(t *testing.T) {
 	firstCall := true
-	accessToken1 := "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI"
-	accessToken2 := "3yJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		verifyAuthRequest(t, r, "john", "", "King of the North")
+
 		w.WriteHeader(http.StatusOK)
+
 		if firstCall {
-			fmt.Fprintf(w, `{
-				"username":"hello",
-				"role":"user",
-				"permissions":[  
-					"administrator",
-					"deployment_admin"
-				],
-				"sub":"hello",
-				"iss":"John",
-				"aud":"DSX",
-				"uid":"999",
-				"accessToken": %q,
-				"_messageCode_":"success",
-				"message":"success"
-			}`, accessToken1)
+			fmt.Fprintf(w, `{ "_messageCode_":"200", "message":"success", "token":"%s"}`, cp4dUsernameApikey1)
 			firstCall = false
-			username, password, ok := r.BasicAuth()
-			assert.Equal(t, true, ok)
-			assert.Equal(t, "john", username)
-			assert.Equal(t, "snow", password)
 		} else {
-			fmt.Fprintf(w, `{
-				"username": "admin",
-  				"role": "Admin",
-  				"permissions": [
-    				"administrator",
-    				"manage_catalog",
-    				"access_catalog",
-    				"manage_policies",
-    				"access_policies",
-    				"virtualize_transform",
-    				"can_provision",
-    				"deployment_admin"
-  				],
-  				"sub": "admin",
-  				"iss": "test",
-  				"aud": "DSX",
-  				"uid": "999",
-  				"accessToken": %q,
-  				"_messageCode_": "success",
-  				"message": "success"
-			}`, accessToken2)
-			username, password, ok := r.BasicAuth()
-			assert.Equal(t, true, ok)
-			assert.Equal(t, "john", username)
-			assert.Equal(t, "snow", password)
+			fmt.Fprintf(w, `{ "_messageCode_":"200", "message":"success", "token":"%s"}`, cp4dUsernameApikey2)
 		}
 	}))
 	defer server.Close()
 
-	authenticator, err := NewCloudPakForDataAuthenticator(server.URL, "john", "snow", false, nil)
+	authenticator, err := NewCloudPakForDataAuthenticatorUsingAPIKey(server.URL, "john", "King of the North", false, nil)
 	assert.Nil(t, err)
 	assert.Nil(t, authenticator.tokenData)
 
 	// // Force the first fetch and verify we got the first access token.
 	token, err := authenticator.getToken()
 	assert.Nil(t, err)
-	assert.Equal(t, accessToken1,
-		token)
+	assert.Equal(t, cp4dUsernameApikey1, token)
 	assert.NotNil(t, authenticator.tokenData)
 
-	// Now simulate the client being idle for 10 minutes into the refresh time
+	// Now simulate the client being idle for 10 minutes into the refresh time.
 	authenticator.tokenData.Expiration = GetCurrentTime() + 3600
 	tenMinutesBeforeNow := GetCurrentTime() - 600
 	authenticator.tokenData.RefreshTime = tenMinutesBeforeNow
+
 	// Authenticator should detect the need to refresh and request a new access token IN THE BACKGROUND when we call
-	// getToken() again. The immediate response should be the token which was already stored, since it's not yet
-	// expired.
+	// getToken() again. The immediate response should be the token which was already stored, since it's not yet expired.
 	token, err = authenticator.getToken()
 	assert.Nil(t, err)
-	assert.Equal(t, accessToken1,
-		token)
+	assert.Equal(t, cp4dUsernameApikey1, token)
 	assert.NotNil(t, authenticator.tokenData)
-	// RefreshTime should have advanced by 1 minute from the current time
+
+	// RefreshTime should have advanced by 1 minute from the current time.
 	newRefreshTime := GetCurrentTime() + 60
 	assert.Equal(t, newRefreshTime, authenticator.tokenData.RefreshTime)
 
@@ -463,39 +509,25 @@ func TestCp4dBackgroundTokenRefreshIdle(t *testing.T) {
 	// a goroutine & refreshed the token.
 	token, err = authenticator.getToken()
 	assert.Nil(t, err)
-	assert.Equal(t, accessToken1,
-		token)
+	assert.Equal(t, cp4dUsernameApikey1, token)
 	assert.NotNil(t, authenticator.tokenData)
 	assert.Equal(t, newRefreshTime, authenticator.tokenData.RefreshTime)
-	// // Wait for the background thread to finish and verify both the RefreshTime & tokenData were updated
+
+	// Wait for the background thread to finish and verify both the RefreshTime & tokenData were updated
 	time.Sleep(5 * time.Second)
 	token, err = authenticator.getToken()
 	assert.Nil(t, err)
-	assert.Equal(t, accessToken2,
-		token)
+	assert.Equal(t, cp4dUsernameApikey2, token)
 	assert.NotNil(t, authenticator.tokenData)
 	assert.NotEqual(t, newRefreshTime, authenticator.tokenData.RefreshTime)
-
 }
 
 func TestCp4dDisableSSL(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		verifyAuthRequest(t, r, "mookie", "betts", "")
+
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `{
-			"username":"hello",
-			"role":"user",
-			"permissions":[  
-				"administrator",
-				"deployment_admin"
-			],
-			"sub":"hello",
-			"iss":"John",
-			"aud":"DSX",
-			"uid":"999",
-			"accessToken":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-			"_messageCode_":"success",
-			"message":"success"
-		}`)
+		fmt.Fprintf(w, `{ "_messageCode_":"200", "message":"success", "token":"%s"}`, cp4dUsernamePwd1)
 	}))
 	defer server.Close()
 
@@ -507,8 +539,7 @@ func TestCp4dDisableSSL(t *testing.T) {
 	}
 
 	token, err := authenticator.getToken()
-	assert.Equal(t, "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-		token)
+	assert.Equal(t, cp4dUsernamePwd1, token)
 	assert.Nil(t, err)
 	assert.NotNil(t, authenticator.Client)
 	assert.NotNil(t, authenticator.Client.Transport)
@@ -520,28 +551,12 @@ func TestCp4dDisableSSL(t *testing.T) {
 
 func TestCp4dUserHeaders(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `{
-			"username":"hello",
-			"role":"user",
-			"permissions":[  
-				"administrator",
-				"deployment_admin"
-			],
-			"sub":"hello",
-			"iss":"John",
-			"aud":"DSX",
-			"uid":"999",
-			"accessToken":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-			"_messageCode_":"success",
-			"message":"success"
-		}`)
-		username, password, ok := r.BasicAuth()
-		assert.Equal(t, true, ok)
-		assert.Equal(t, "mookie", username)
-		assert.Equal(t, "betts", password)
+		verifyAuthRequest(t, r, "mookie", "", "King of the North")
 		assert.Equal(t, "Value1", r.Header.Get("Header1"))
 		assert.Equal(t, "Value2", r.Header.Get("Header2"))
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `{ "_messageCode_":"200", "message":"success", "token":"%s"}`, cp4dUsernameApikey1)
 	}))
 	defer server.Close()
 
@@ -552,46 +567,13 @@ func TestCp4dUserHeaders(t *testing.T) {
 	authenticator := &CloudPakForDataAuthenticator{
 		URL:      server.URL,
 		Username: "mookie",
-		Password: "betts",
+		APIKey:   "King of the North",
 		Headers:  headers,
 	}
 
 	token, err := authenticator.getToken()
-	assert.Equal(t, "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-		token)
+	assert.Equal(t, cp4dUsernameApikey1, token)
 	assert.Nil(t, err)
-}
-
-func TestGetTokenFailure(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte("Sorry you are forbidden"))
-	}))
-	defer server.Close()
-
-	authenticator := &CloudPakForDataAuthenticator{
-		URL:      server.URL,
-		Username: "john",
-		Password: "snow",
-	}
-
-	var expectedResponse = []byte("Sorry you are forbidden")
-
-	_, err := authenticator.getToken()
-	assert.NotNil(t, err)
-	assert.Equal(t, "Sorry you are forbidden", err.Error())
-	// We expect an AuthenticationError to be returned, so cast the returned error
-	authError, ok := err.(*AuthenticationError)
-	assert.True(t, ok)
-	assert.NotNil(t, authError)
-	assert.NotNil(t, authError.Error())
-	assert.NotNil(t, authError.Response)
-	rawResult := authError.Response.GetRawResult()
-	assert.NotNil(t, rawResult)
-	assert.Equal(t, expectedResponse, rawResult)
-	statusCode := authError.Response.GetStatusCode()
-	assert.Equal(t, "Sorry you are forbidden", authError.Error())
-	assert.Equal(t, http.StatusForbidden, statusCode)
 }
 
 func TestNewCloudPakForDataAuthenticatorFromMap(t *testing.T) {
@@ -619,6 +601,13 @@ func TestNewCloudPakForDataAuthenticatorFromMap(t *testing.T) {
 	assert.NotNil(t, err)
 
 	props = map[string]string{
+		PROPNAME_AUTH_URL: "cp4d-url",
+		PROPNAME_APIKEY:   "my_apikey",
+	}
+	_, err = newCloudPakForDataAuthenticatorFromMap(props)
+	assert.NotNil(t, err)
+
+	props = map[string]string{
 		PROPNAME_AUTH_URL:         "cp4d-url",
 		PROPNAME_USERNAME:         "mookie",
 		PROPNAME_PASSWORD:         "betts",
@@ -630,70 +619,56 @@ func TestNewCloudPakForDataAuthenticatorFromMap(t *testing.T) {
 	assert.Equal(t, "cp4d-url", authenticator.URL)
 	assert.Equal(t, "mookie", authenticator.Username)
 	assert.Equal(t, "betts", authenticator.Password)
+	assert.Empty(t, authenticator.APIKey)
+	assert.Equal(t, true, authenticator.DisableSSLVerification)
+
+	props = map[string]string{
+		PROPNAME_AUTH_URL:         "cp4d-url",
+		PROPNAME_USERNAME:         "mookie",
+		PROPNAME_APIKEY:           "my_apikey",
+		PROPNAME_AUTH_DISABLE_SSL: "true",
+	}
+	authenticator, err = newCloudPakForDataAuthenticatorFromMap(props)
+	assert.Nil(t, err)
+	assert.NotNil(t, authenticator)
+	assert.Equal(t, "cp4d-url", authenticator.URL)
+	assert.Equal(t, "mookie", authenticator.Username)
+	assert.Empty(t, authenticator.Password)
+	assert.Equal(t, "my_apikey", authenticator.APIKey)
 	assert.Equal(t, true, authenticator.DisableSSLVerification)
 }
 
 func TestCp4dGetTokenTimeoutError(t *testing.T) {
 	firstCall := true
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		verifyAuthRequest(t, r, "john", "", "King of the North")
+
 		w.WriteHeader(http.StatusOK)
+
 		if firstCall {
-			fmt.Fprintf(w, `{
-				"username":"hello",
-				"role":"user",
-				"permissions":[
-					"administrator",
-					"deployment_admin"
-				],
-				"sub":"hello",
-				"iss":"John",
-				"aud":"DSX",
-				"uid":"999",
-				"accessToken":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-				"_messageCode_":"success",
-				"message":"success"
-			}`)
+			fmt.Fprintf(w, `{ "_messageCode_":"200", "message":"success", "token":"%s"}`, cp4dUsernameApikey1)
 			firstCall = false
 		} else {
 			time.Sleep(3 * time.Second)
-			fmt.Fprintf(w, `{
-				"username": "admin",
-  				"role": "Admin",
-  				"permissions": [
-    				"administrator",
-    				"manage_catalog",
-    				"access_catalog",
-    				"manage_policies",
-    				"access_policies",
-    				"virtualize_transform",
-    				"can_provision",
-    				"deployment_admin"
-  				],
-  				"sub": "admin",
-  				"iss": "test",
-  				"aud": "DSX",
-  				"uid": "999",
-  				"accessToken": "3yJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-  				"_messageCode_": "success",
-  				"message": "success"
-			}`)
+			fmt.Fprintf(w, `{ "_messageCode_":"200", "message":"success", "token":"%s"}`, cp4dUsernameApikey2)
 		}
 	}))
 	defer server.Close()
 
-	authenticator, err := NewCloudPakForDataAuthenticator(server.URL, "john", "snow", false, nil)
+	authenticator, err := NewCloudPakForDataAuthenticatorUsingAPIKey(server.URL, "john", "King of the North", false, nil)
 	assert.Nil(t, err)
 	assert.Nil(t, authenticator.tokenData)
 
 	// Force the first fetch and verify we got the first access token.
 	token, err := authenticator.getToken()
 	assert.Nil(t, err)
-	assert.Equal(t, "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-		token)
+	assert.Equal(t, cp4dUsernameApikey1, token)
 	assert.NotNil(t, authenticator.tokenData)
 
 	// Force expiration and verify that we got a timeout error
 	authenticator.tokenData.Expiration = GetCurrentTime() - 3600
+
 	// Set the client timeout to something very low
 	authenticator.Client.Timeout = time.Second * 2
 	token, err = authenticator.getToken()
@@ -708,48 +683,35 @@ func TestCp4dGetTokenTimeoutError(t *testing.T) {
 func TestCp4dGetTokenServerError(t *testing.T) {
 	firstCall := true
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		verifyAuthRequest(t, r, "john", "snow", "")
+
 		if firstCall {
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintf(w, `{
-				"username":"hello",
-				"role":"user",
-				"permissions":[
-					"administrator",
-					"deployment_admin"
-				],
-				"sub":"hello",
-				"iss":"John",
-				"aud":"DSX",
-				"uid":"999",
-				"accessToken":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-				"_messageCode_":"success",
-				"message":"success"
-			}`)
+			fmt.Fprintf(w, `{ "_messageCode_":"200", "message":"success", "token":"%s"}`, cp4dUsernamePwd1)
 			firstCall = false
 		} else {
 			w.WriteHeader(http.StatusGatewayTimeout)
-			_, _ = w.Write([]byte("Gateway Timeout"))
+			fmt.Fprintf(w, "Gateway Timeout")
 		}
 	}))
 	defer server.Close()
 
-	authenticator, err := NewCloudPakForDataAuthenticator(server.URL, "john", "snow", false, nil)
+	authenticator, err := NewCloudPakForDataAuthenticatorUsingPassword(server.URL, "john", "snow", false, nil)
 	assert.Nil(t, err)
 	assert.Nil(t, authenticator.tokenData)
 
 	// Force the first fetch and verify we got the first access token.
 	token, err := authenticator.getToken()
 	assert.Nil(t, err)
-	assert.Equal(t, "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI",
-		token)
+	assert.Equal(t, cp4dUsernamePwd1, token)
 	assert.NotNil(t, authenticator.tokenData)
 
-	var expectedResponse = []byte("Gateway Timeout")
-
-	// Force expiration and verify that we got a server error
+	// Force expiration and verify that we got a server error.
 	authenticator.tokenData.Expiration = GetCurrentTime() - 3600
 	token, err = authenticator.getToken()
 	assert.NotNil(t, err)
+
 	// We expect an AuthenticationError to be returned, so cast the returned error
 	authError, ok := err.(*AuthenticationError)
 	assert.True(t, ok)
@@ -758,9 +720,74 @@ func TestCp4dGetTokenServerError(t *testing.T) {
 	assert.NotNil(t, authError.Error())
 	rawResult := authError.Response.GetRawResult()
 	statusCode := authError.Response.GetStatusCode()
-	assert.Equal(t, "Gateway Timeout", authError.Error())
-	assert.Equal(t, expectedResponse, rawResult)
 	assert.NotNil(t, rawResult)
+	assert.Equal(t, "Gateway Timeout", authError.Error())
+	assert.Equal(t, []byte("Gateway Timeout"), rawResult)
 	assert.Equal(t, http.StatusGatewayTimeout, statusCode)
-	assert.Equal(t, "", token)
+	assert.Empty(t, token)
 }
+
+//
+// In order to test with a live CP4D server, create file "cp4dtest.env" in the project root.
+// It should look like this:
+//
+// CP4DTEST1_AUTH_URL=<url>   e.g. https://cpd350-cpd-cpd350.apps.wml-kf-cluster.os.fyre.ibm.com/icp4d-api
+// CP4DTEST1_AUTH_TYPE=cp4d
+// CP4DTEST1_USERNAME=<username>
+// CP4DTEST1_PASSWORD=<password>
+// CP4DTEST1_AUTH_DISABLE_SSL=true
+//
+// CP4DTEST2_AUTH_URL=<url>   e.g. https://cpd350-cpd-cpd350.apps.wml-kf-cluster.os.fyre.ibm.com/icp4d-api
+// CP4DTEST2_AUTH_TYPE=cp4d
+// CP4DTEST2_USERNAME=<username>
+// CP4DTEST2_APIKEY=<apikey>
+// CP4DTEST2_AUTH_DISABLE_SSL=true
+//
+// Then uncomment the function below, then run these commands:
+// cd v4/core
+// go test -v -tags=auth -run=TestCp4dListTokenServer
+//
+
+// func TestCp4dLiveTokenServer(t *testing.T) {
+// 	var request *http.Request
+// 	var err error
+// 	var authHeader string
+
+// 	// Get two cp4d authenticators from the environment.
+// 	// "cp4dtest1" uses username/password
+// 	// "cp4dtest2" uses username/apikey
+// 	os.Setenv("IBM_CREDENTIALS_FILE", "../../cp4dtest.env")
+
+// 	auth1, err := GetAuthenticatorFromEnvironment("cp4dtest1")
+// 	assert.Nil(t, err)
+// 	assert.NotNil(t, auth1)
+
+// 	auth2, err := GetAuthenticatorFromEnvironment("cp4dtest2")
+// 	assert.Nil(t, err)
+// 	assert.NotNil(t, auth2)
+
+// 	// Create a new Request object.
+// 	builder, err := NewRequestBuilder("GET").ResolveRequestURL("https://localhost/placeholder/url", "", nil)
+// 	assert.Nil(t, err)
+// 	assert.NotNil(t, builder)
+
+// 	request, _ = builder.Build()
+// 	assert.NotNil(t, request)
+// 	err = auth1.Authenticate(request)
+// 	assert.Nil(t, err)
+
+// 	authHeader = request.Header.Get("Authorization")
+// 	assert.NotEmpty(t, authHeader)
+// 	assert.True(t, strings.HasPrefix(authHeader, "Bearer "))
+// 	t.Logf("Authorization: %s\n", authHeader)
+
+// 	request, _ = builder.Build()
+// 	assert.NotNil(t, request)
+// 	err = auth2.Authenticate(request)
+// 	assert.Nil(t, err)
+
+// 	authHeader = request.Header.Get("Authorization")
+// 	assert.NotEmpty(t, authHeader)
+// 	assert.True(t, strings.HasPrefix(authHeader, "Bearer "))
+// 	t.Logf("Authorization: %s\n", authHeader)
+// }

--- a/v4/core/jwt_utils.go
+++ b/v4/core/jwt_utils.go
@@ -1,0 +1,57 @@
+package core
+
+// (C) Copyright IBM Corp. 2021.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	jwt "github.com/dgrijalva/jwt-go"
+)
+
+// coreJWTClaims are the fields within a JWT's "claims" segment that we're interested in.
+type coreJWTClaims struct {
+	ExpiresAt int64 `json:"exp,omitempty"`
+	IssuedAt  int64 `json:"iat,omitempty"`
+}
+
+// parseJWT parses the specified JWT token string and returns an instance of the coreJWTClaims struct.
+func parseJWT(tokenString string) (claims *coreJWTClaims, err error) {
+	// A JWT consists of three .-separated segments
+	segments := strings.Split(tokenString, ".")
+	if len(segments) != 3 {
+		err = fmt.Errorf("token contains an invalid number of segments")
+		return
+	}
+
+	// Parse Claims segment.
+	var claimBytes []byte
+	claimBytes, err = jwt.DecodeSegment(segments[1])
+	if err != nil {
+		err = fmt.Errorf("error decoding claims segment: %s", err.Error())
+		return
+	}
+
+	// Now deserialize the claims segment into our coreClaims struct.
+	claims = &coreJWTClaims{}
+	err = json.Unmarshal(claimBytes, claims)
+	if err != nil {
+		err = fmt.Errorf("error unmarshalling token: %s", err.Error())
+		return
+	}
+
+	return
+}

--- a/v4/core/jwt_utils_test.go
+++ b/v4/core/jwt_utils_test.go
@@ -1,0 +1,55 @@
+// +build all fast auth
+
+package core
+
+// (C) Copyright IBM Corp. 2021.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	// These two access tokens are the result of running curl to invoke
+	// the POST /v1/authorize against a CP4D environment.
+
+	// Username/password
+	// curl -k -X POST https://<host>/icp4d-api/v1/authorize -H 'Content-Type: application/json' \
+	//      -d '{"username": "testuser", "password": "<password>" }'
+	jwtUserPwd = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3R1c2VyIiwicm9sZSI6IlVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhY2Nlc3NfY2F0YWxvZyIsImNhbl9wcm92aXNpb24iLCJzaWduX2luX29ubHkiXSwiZ3JvdXBzIjpbMTAwMDBdLCJzdWIiOiJ0ZXN0dXNlciIsImlzcyI6IktOT1hTU08iLCJhdWQiOiJEU1giLCJ1aWQiOiIxMDAwMzMxMDAzIiwiYXV0aGVudGljYXRvciI6ImRlZmF1bHQiLCJpYXQiOjE2MTA1NDgxNjksImV4cCI6MTYxMDU5MTMzM30.AGbjQwWDQ7KG7Ef5orTH982kLmwExmj0eiDe3nke8frcm0EfshglU1nddIVBhrEI6vkrHZQSUoolLT6Kz1hUrbbRedC6E-XmJwPG9HcfG9BsW6CJ4hN5IbrJDf9maDBvKDLsEjH6YPTiAoMDNKsxLImHFms0GbIREAj_7Q7Xb2jpQYPR1JG32GAclq01deY8n4whE6WeyQqcbHUCGy3Q7sKddqEvT59XjLr1Mwm1uvIGnso_FkWJhvZs_z4aF0rVQes7gJZpOOSPkuA7l08KxvFmX3vF0IqmfudymEqaW9YH2ihAvHQBOJJtIkKaRga2TYyvfcwLFCXOABEi2lBOuQ"
+
+	// Username/apikey
+	// curl -k -X POST https://<host>/icp4d-api/v1/authorize -H 'Content-Type: application/json' \
+	//      -d '{"username": "testuser", "api_key": "<apikey>" }'
+	jwtUserApikey = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3R1c2VyIiwicm9sZSI6IlVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhY2Nlc3NfY2F0YWxvZyIsImNhbl9wcm92aXNpb24iLCJzaWduX2luX29ubHkiXSwiZ3JvdXBzIjpbMTAwMDBdLCJzdWIiOiJ0ZXN0dXNlciIsImlzcyI6IktOT1hTU08iLCJhdWQiOiJEU1giLCJ1aWQiOiIxMDAwMzMxMDAzIiwiYXV0aGVudGljYXRvciI6ImRlZmF1bHQiLCJpYXQiOjE2MTA1NDgyNDgsImV4cCI6MTYxMDU5MTQxMn0.I8MgxrapKRt0nOn0F41NtLHQ5HGmInZNaJIWcNwyBgLWI5YY_98kpKLecN5d9Ll9g0_lapAFs_b8xpTya0Lvnp2Q81SloRFpDhAMUVHVWq46g2dvZd1JpoFB8NHwrkz2qE_JUHBIonJmQusy8vMm1m1CPy0pE6fTYH1d5EJG2vLo6f2eFiDizLfGxb0ym9lUOkK6dgNZw2T32N8IoSYNan6BQU25Jai6llWRLwZda7R521EPEw2AtPDsd95AxoTd8f4pptxfkL2uXpT35wRguap_09sRlvDTR18Ghs-GbtCh3Do-8OPGEFYKvJkSHNpiXPw8pvHEe5jCGl3l3F5vXQ"
+)
+
+func TestParseJWT(t *testing.T) {
+	var err error
+	var claims *coreJWTClaims
+
+	claims, err = parseJWT(jwtUserPwd)
+	assert.Nil(t, err)
+	assert.NotNil(t, claims)
+	assert.Equal(t, int64(1610591333), claims.ExpiresAt)
+	assert.Equal(t, int64(1610548169), claims.IssuedAt)
+
+	claims, err = parseJWT(jwtUserApikey)
+	assert.Nil(t, err)
+	assert.NotNil(t, claims)
+	assert.Equal(t, int64(1610591412), claims.ExpiresAt)
+	assert.Equal(t, int64(1610548248), claims.IssuedAt)
+}

--- a/v4/go.mod
+++ b/v4/go.mod
@@ -3,8 +3,7 @@ module github.com/IBM/go-sdk-core/v4
 go 1.12
 
 require (
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
-	github.com/form3tech-oss/jwt-go v3.2.1+incompatible
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/go-openapi/strfmt v0.19.10
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1

--- a/v4/go.sum
+++ b/v4/go.sum
@@ -7,8 +7,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/form3tech-oss/jwt-go v3.2.1+incompatible h1:xdtqez379uWVJ9P3qQMX8W+F/nqsTdUvyMZB36tnacA=
-github.com/form3tech-oss/jwt-go v3.2.1+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=


### PR DESCRIPTION
Fixes arf/planning-sdk-squad#2344

This commit enhances the CP4D Authenticator to support
the username/apikey use case.  With these changes, a user
has the ability to construct a CP4D authenticator using either
a username/password pair or a username/apikey pair.
The authenticator will now use the official
"POST /v1/authorize" operation for obtaining an access token.