### PR TITLE
feat(logger): support logging to stdout and stderr

### DIFF
--- a/v4/core/request_builder.go
+++ b/v4/core/request_builder.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/http/httputil"
 	"net/textproto"
 	"net/url"
 	"os"
@@ -362,6 +363,12 @@ func (requestBuilder *RequestBuilder) Build() (req *http.Request, err error) {
 	// Finally, if a Context should be associated with the new Request instance, then set it.
 	if !IsNil(requestBuilder.ctx) {
 		req = req.WithContext(requestBuilder.ctx)
+	}
+
+	// Provide a way for the user to print out the request, for debugging purposes
+	dumpedRequest, dumpErr := httputil.DumpRequestOut(req, req.Body != nil)
+	if dumpErr == nil {
+		GetLogger().Debug("Request:\n" + string(dumpedRequest))
 	}
 
 	return


### PR DESCRIPTION
Currently, all logs performed by the default logger in the Go core will print to Stdout.
However, error messages should be logged to Stderr. This PR implements a change to the logger
that sends error logs to Stderr and all other logs to Stdout.

Additionally, this PR adds a log statement to the request builder to log the full request
for debugging purposes.