### PR TITLE
Minor improvement to logging implementation

### DIFF
--- a/v4/core/log.go
+++ b/v4/core/log.go
@@ -36,6 +36,8 @@ const (
 // Users of the library can supply their own implementation by calling SetLogger().
 type Logger interface {
 	Log(level LogLevel, format string, inserts ...interface{})
+	// TODO: add in next major release
+	//SetLogLevel(level LogLevel)
 	Error(format string, inserts ...interface{})
 	Warn(format string, inserts ...interface{})
 	Info(format string, inserts ...interface{})
@@ -94,6 +96,11 @@ func (l *SDKLoggerImpl) Debug(format string, inserts ...interface{}) {
 	l.Log(LevelDebug, "[Debug] "+format, inserts...)
 }
 
+// Sets the loglevel of the target logger to "level"
+func (l *SDKLoggerImpl) SetLogLevel(level LogLevel) {
+	l.logLevel = level
+}
+
 // NewLogger constructs an SDKLoggerImpl instance with the specified logging level
 // enabled and the specified log.Logger instance as the underlying logger to use.
 // If "stdLogger" is nil, then a default log.Logger instance will be used.
@@ -119,5 +126,9 @@ func GetLogger() Logger {
 
 // SetLoggingLevel will enable the specified logging level in the Go core library.
 func SetLoggingLevel(level LogLevel) {
-	SetLogger(NewLogger(level, nil))
+	if l, ok := sdkLogger.(*SDKLoggerImpl); ok {
+		l.SetLogLevel(level)
+	} else {
+		SetLogger(NewLogger(level, nil))
+	}
 }

--- a/v4/core/log_test.go
+++ b/v4/core/log_test.go
@@ -123,3 +123,27 @@ func TestLogDebug(t *testing.T) {
 	l.Debug("debug msg")
 	assert.Equal(t, "[Debug] debug msg\n", buf.String())
 }
+
+func TestSetLoggingLevel(t *testing.T) {
+	buf, l := stringLogger(LevelError)
+
+	SetLogger(l)
+
+	l.Debug("debug msg")
+	assert.Empty(t, buf.String())
+	buf.Reset()
+
+	GetLogger().Debug("debug msg")
+	assert.Empty(t, buf.String())
+	buf.Reset()
+
+	SetLoggingLevel(LevelDebug)
+
+	l.Debug("debug msg")
+	assert.Equal(t, "[Debug] debug msg\n", buf.String())
+	buf.Reset()
+
+	GetLogger().Debug("debug msg")
+	assert.Equal(t, "[Debug] debug msg\n", buf.String())
+	buf.Reset()
+}


### PR DESCRIPTION
This PR makes a small improvement to the `SetLoggingLevel` method to only completely replace the current logger in the (unlikely) situation where the logger is a "custom" implementation of the `Logger` class, and not an `SDKLoggerImpl`. The prior behavior of replacing the logger just to set the logging level is not what most users would expect from a "Set" method.

In the next major release, we should add `SetLogLevel` to the `Logger` interface to make the behavior of `SetLoggingLevel` consistent for custom `Logger` implementations.