### PR TITLE
fix: ensure result value is set if err is nil

### DIFF
--- a/v5/core/base_service.go
+++ b/v5/core/base_service.go
@@ -483,9 +483,18 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 
 				// And set the string in the Result field.
 				detailedResponse.Result = &responseString
-			} else {
-				// Last resort is to just set the detailedResponse.Result field to be the response body ([]byte).
+			} else if reflect.TypeOf(result).String() == "*[]uint8" { // byte is an alias for uint8
+				rResult := reflect.ValueOf(result).Elem()
+				rResult.Set(reflect.ValueOf(responseBody))
+
+				// And set the byte slice in the Result field.
 				detailedResponse.Result = responseBody
+			} else {
+				// At this point, we don't know how to set the result field, so we have to return an error
+				// But make sure we save the bytes we read in the DetailedResponse for debugging purposes
+				detailedResponse.Result = responseBody
+				err = fmt.Errorf(ERRORMSG_UNEXPECTED_RESPONSE)
+				return
 			}
 		}
 	}

--- a/v5/core/base_service_retries_test.go
+++ b/v5/core/base_service_retries_test.go
@@ -344,8 +344,7 @@ var _ = Describe(`Retry scenarios`, func() {
 				service, builder := clientInit("HEAD", server.URL, 5, 10)
 				req, _ := builder.Build()
 
-				var foo *Foo
-				resp, err := service.Request(req, &foo)
+				resp, err := service.Request(req, nil)
 				Expect(err).To(BeNil())
 				assertResponse(resp, http.StatusOK, "")
 				Expect(resp.GetHeaders().Get("Server-Name")).To(Equal("My Server"))
@@ -356,8 +355,7 @@ var _ = Describe(`Retry scenarios`, func() {
 				service, builder := clientInit("OPTIONS", server.URL, 5, 10)
 				req, _ := builder.Build()
 
-				var foo *Foo
-				resp, err := service.Request(req, &foo)
+				resp, err := service.Request(req, nil)
 				Expect(err).To(BeNil())
 				assertResponse(resp, http.StatusOK, "")
 				Expect(resp.GetHeaders().Get("Server-Name")).To(Equal("My Server"))

--- a/v5/core/constants.go
+++ b/v5/core/constants.go
@@ -61,6 +61,7 @@ const (
 		"and/or use the DisableSSLVerification option of the authenticator."
 	ERRORMSG_AUTHENTICATE_ERROR      = "An error occurred while performing the 'authenticate' step: %s"
 	ERRORMSG_READ_RESPONSE_BODY      = "An error occurred while reading the response body: %s"
+	ERRORMSG_UNEXPECTED_RESPONSE     = "The response contained unexpected content"
 	ERRORMSG_UNMARSHAL_RESPONSE_BODY = "An error occurred while unmarshalling the response body: %s"
 	ERRORMSG_NIL_SLICE               = "The 'slice' parameter cannot be nil"
 	ERRORMSG_PARAM_NOT_SLICE         = "The 'slice' parameter must be a slice"

--- a/v5/core/unmarshal_v2.go
+++ b/v5/core/unmarshal_v2.go
@@ -30,6 +30,7 @@ const (
 	errorIncorrectInputType      = "expected 'rawInput' to be a %s but was %s"
 	errorUnsupportedMapEntryType = "unsupported map entry type: %s"
 	errorUnsupportedResultType   = "unsupported 'result' type: %s"
+	errorUnmarshallInputIsNil    = "input to unmarshall is nil"
 )
 
 //
@@ -158,6 +159,12 @@ type ModelUnmarshaller func(rawInput map[string]json.RawMessage, result interfac
 //                    |                          | contains an instance of map[string][]Foo
 // -------------------+--------------------------+------------------------------------------------------------------
 func UnmarshalModel(rawInput interface{}, propertyName string, result interface{}, unmarshaller ModelUnmarshaller) (err error) {
+
+	// Make sure some input is provided. Otherwise return an error
+	if IsNil(rawInput) {
+		err = fmt.Errorf(errorUnmarshallInputIsNil)
+		return
+	}
 
 	// Reflect on 'result' to determine the type of unmarshal operation being requested.
 	rResultType := reflect.TypeOf(result).Elem()

--- a/v5/core/unmarshal_v2_models_test.go
+++ b/v5/core/unmarshal_v2_models_test.go
@@ -173,6 +173,11 @@ func TestUnmarshalModelInstance(t *testing.T) {
 	assert.NotNil(t, myModel)
 	assert.Equal(t, "string1", *(myModel.Foo))
 	assert.Equal(t, int64(44), *(myModel.Bar))
+
+	// Unmarshal with "zero" input should return an error
+	var zeroRawMap map[string]json.RawMessage
+	err = UnmarshalModel(zeroRawMap, "", &myModel, UnmarshalMyModel)
+	assert.NotNil(t, err)
 }
 
 func TestUnmarshalModelSliceNil(t *testing.T) {
@@ -221,6 +226,11 @@ func TestUnmarshalModelSlice(t *testing.T) {
 	assert.Equal(t, int64(44), *(mySlice[0].Bar))
 	assert.Equal(t, "string2", *(mySlice[1].Foo))
 	assert.Equal(t, int64(74), *(mySlice[1].Bar))
+
+	// Unmarshal with "zero" input should return an error
+	var zeroSlice []json.RawMessage
+	err = UnmarshalModel(zeroSlice, "", &mySlice, UnmarshalMyModel)
+	assert.NotNil(t, err)
 }
 
 func TestUnmarshalModelMapNil(t *testing.T) {


### PR DESCRIPTION
This PR addresses a corner case in the base_service `Request` method where it could return a nil `err` but not set the `result` value passed by the user.  This behavior would force users to check explicitly for `result != nil` in addition to checking for `err == nil`, which is a poor experience for the user, particularly since they will likely just manufacture an error for this case anyway.

I also made a small change to check for a nil input to `UnmarshallModel`, since this method should treat this condition as an error rather than silently returning and empty result as it had been.

Tests are updated.