### PR TITLE
feat: add UUID, date, and datetime helpers for terraform usage

### DIFF
--- a/v5/core/datetime.go
+++ b/v5/core/datetime.go
@@ -71,3 +71,17 @@ func init() {
 func NormalizeDateTimeUTC(t time.Time) time.Time {
 	return t.UTC()
 }
+
+// ParseDate parses the specified RFC3339 full-date string (YYYY-MM-DD) and returns a strfmt.Date instance.
+func ParseDate(dateString string) (fmtDate strfmt.Date, err error) {
+	formattedTime, err := time.Parse(strfmt.RFC3339FullDate, dateString)
+	if err == nil {
+		fmtDate = strfmt.Date(formattedTime)
+	}
+	return
+}
+
+// ParseDateTime parses the specified date-time string and returns a strfmt.DateTime instance.
+func ParseDateTime(dateString string) (strfmt.DateTime, error) {
+	return strfmt.ParseDateTime(dateString)
+}

--- a/v5/core/datetime_test.go
+++ b/v5/core/datetime_test.go
@@ -21,6 +21,7 @@ package core
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
@@ -159,5 +160,25 @@ func TestModelsDate(t *testing.T) {
 	roundTripTestDate(t, `{"ws_victory":"2007-10-29"}`, `{"ws_victory":"2007-10-29"}`)
 	roundTripTestDate(t, `{"ws_victory":"2013-10-31"}`, `{"ws_victory":"2013-10-31"}`)
 	roundTripTestDate(t, `{"ws_victory":"2018-10-29"}`, `{"ws_victory":"2018-10-29"}`)
+}
 
+func TestDateTimeUtil(t *testing.T) {
+	dateVar := strfmt.Date(time.Now())
+	fmtDate, err := ParseDate(dateVar.String())
+	assert.Nil(t, err)
+	assert.Equal(t, dateVar.String(), fmtDate.String())
+
+	fmtDate, err = ParseDate("not a date")
+	assert.Equal(t, strfmt.Date{}, fmtDate)
+	assert.NotNil(t, err)
+
+	dateTimeVar := strfmt.DateTime(time.Now())
+	var fmtDTime strfmt.DateTime
+	fmtDTime, err = ParseDateTime(dateTimeVar.String())
+	assert.Nil(t, err)
+	assert.Equal(t, dateTimeVar.String(), fmtDTime.String())
+
+	fmtDTime, err = ParseDateTime("not a datetime")
+	assert.Equal(t, strfmt.DateTime{}, fmtDTime)
+	assert.NotNil(t, err)
 }

--- a/v5/core/utils.go
+++ b/v5/core/utils.go
@@ -26,8 +26,8 @@ import (
 	"strings"
 	"time"
 
-	validator "gopkg.in/go-playground/validator.v9"
 	"github.com/go-openapi/strfmt"
+	validator "gopkg.in/go-playground/validator.v9"
 )
 
 // Validate is a shared validator instance used to perform validation of structs.
@@ -186,27 +186,6 @@ func PrettyPrint(result interface{}, resultName string) {
 // GetCurrentTime returns the current Unix time.
 func GetCurrentTime() int64 {
 	return time.Now().Unix()
-}
-
-// ParseDate parses the specified RFC3339 full-date string (YYYY-MM-DD) and returns a strfmt.Date instance.
-func ParseDate(dateString string) (fmtDate strfmt.Date, err error) {
-	formattedTime, err := time.Parse(strfmt.RFC3339FullDate, dateString)
-	var formattedDate strfmt.Date
-	if err != nil {
-		return formattedDate, err
-	}
-	formattedDate = strfmt.Date(formattedTime)
-	return formattedDate, nil
-}
-
-// ParseDateTime parses the specified date-time string and returns a strfmt.DateTime instance.
-func ParseDateTime(dateString string) (fmtDTime strfmt.DateTime, err error) {
-	var formattedDateTime strfmt.DateTime
-	formattedDateTime, err = strfmt.ParseDateTime(dateString)
-	if err != nil {
-		return formattedDateTime, err
-	}
-	return formattedDateTime, nil
 }
 
 // ConvertSlice Marshals 'slice' to a json string, performs

--- a/v5/core/utils.go
+++ b/v5/core/utils.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	validator "gopkg.in/go-playground/validator.v9"
+	"github.com/go-openapi/strfmt"
 )
 
 // Validate is a shared validator instance used to perform validation of structs.
@@ -109,6 +110,11 @@ func Float64Ptr(literal float64) *float64 {
 	return &literal
 }
 
+// UUIDPtr returns a pointer to strfmt.UUID literal.
+func UUIDPtr(literal strfmt.UUID) *strfmt.UUID {
+	return &literal
+}
+
 // IsJSONMimeType Returns true iff the specified mimeType value represents a
 // "JSON" mimetype.
 func IsJSONMimeType(mimeType string) bool {
@@ -180,6 +186,27 @@ func PrettyPrint(result interface{}, resultName string) {
 // GetCurrentTime returns the current Unix time.
 func GetCurrentTime() int64 {
 	return time.Now().Unix()
+}
+
+// ParseDate parses the specified RFC3339 full-date string (YYYY-MM-DD) and returns a strfmt.Date instance.
+func ParseDate(dateString string) (fmtDate strfmt.Date, err error) {
+	formattedTime, err := time.Parse(strfmt.RFC3339FullDate, dateString)
+	var formattedDate strfmt.Date
+	if err != nil {
+		return formattedDate, err
+	}
+	formattedDate = strfmt.Date(formattedTime)
+	return formattedDate, nil
+}
+
+// ParseDateTime parses the specified date-time string and returns a strfmt.DateTime instance.
+func ParseDateTime(dateString string) (fmtDTime strfmt.DateTime, err error) {
+	var formattedDateTime strfmt.DateTime
+	formattedDateTime, err = strfmt.ParseDateTime(dateString)
+	if err != nil {
+		return formattedDateTime, err
+	}
+	return formattedDateTime, nil
 }
 
 // ConvertSlice Marshals 'slice' to a json string, performs

--- a/v5/core/utils_test.go
+++ b/v5/core/utils_test.go
@@ -225,6 +225,9 @@ func TestPointers(t *testing.T) {
 
 	var float64Var = float64(23)
 	assert.Equal(t, &float64Var, Float64Ptr(float64Var))
+
+	var uuidVar = strfmt.UUID("12345678-1234-1234-1234-123456123456")
+	assert.Equal(t, &uuidVar, UUIDPtr(uuidVar))
 }
 
 func TestConvertSliceFloat64(t *testing.T) {
@@ -316,6 +319,27 @@ func TestConvertSliceByteArray(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Empty(t, convertedSlice)
+}
+
+func TestDateTimeUtil(t *testing.T) {
+	dateVar := strfmt.Date(time.Now())
+	fmtDate, err := ParseDate(dateVar.String())
+	assert.Nil(t, err)
+	assert.Equal(t, dateVar.String(), fmtDate.String())
+
+	fmtDate, err = ParseDate("not a date")
+	assert.Equal(t, strfmt.Date{}, fmtDate)
+	assert.NotNil(t, err)
+
+	dateTimeVar := strfmt.DateTime(time.Now())
+	var fmtDTime strfmt.DateTime
+	fmtDTime, err = ParseDateTime(dateTimeVar.String())
+	assert.Nil(t, err)
+	assert.Equal(t, dateTimeVar.String(), fmtDTime.String())
+
+	fmtDTime, err = ParseDateTime("not a datetime")
+	assert.Equal(t, strfmt.DateTime{}, fmtDTime)
+	assert.NotNil(t, err)
 }
 
 func TestConvertSliceDate(t *testing.T) {

--- a/v5/core/utils_test.go
+++ b/v5/core/utils_test.go
@@ -321,27 +321,6 @@ func TestConvertSliceByteArray(t *testing.T) {
 	assert.Empty(t, convertedSlice)
 }
 
-func TestDateTimeUtil(t *testing.T) {
-	dateVar := strfmt.Date(time.Now())
-	fmtDate, err := ParseDate(dateVar.String())
-	assert.Nil(t, err)
-	assert.Equal(t, dateVar.String(), fmtDate.String())
-
-	fmtDate, err = ParseDate("not a date")
-	assert.Equal(t, strfmt.Date{}, fmtDate)
-	assert.NotNil(t, err)
-
-	dateTimeVar := strfmt.DateTime(time.Now())
-	var fmtDTime strfmt.DateTime
-	fmtDTime, err = ParseDateTime(dateTimeVar.String())
-	assert.Nil(t, err)
-	assert.Equal(t, dateTimeVar.String(), fmtDTime.String())
-
-	fmtDTime, err = ParseDateTime("not a datetime")
-	assert.Equal(t, strfmt.DateTime{}, fmtDTime)
-	assert.NotNil(t, err)
-}
-
 func TestConvertSliceDate(t *testing.T) {
 	date1 := strfmt.Date(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC))
 	date2 := strfmt.Date(time.Date(2020, time.November, 10, 23, 0, 0, 0, time.UTC))


### PR DESCRIPTION
Add helper methods for casting strfmt UUID, Date, and DateTime literals to pointers needed by the go setter methods. Also, this is only parsing dates with RFC3339. This likely needs to be updated in the future to allow other formats to be used.

This is used in the sdk generator PR #873