### PR TITLE
feat: add support for unmarshalling two-dimensional slices of model instances

### DIFF
--- a/v5/core/unmarshal_v2.go
+++ b/v5/core/unmarshal_v2.go
@@ -54,6 +54,7 @@ const (
 //   - *<primitive-type>
 //   - **<primitive-type>
 //   - *[]<primitive-type>
+//   - *[][]<primitive-type>
 //   - *map[string]<primitive-type>
 //   - *map[string][]<primitive-type>
 //   - *[]map[string]<primitive-type>
@@ -61,7 +62,7 @@ const (
 //
 // Where <primitive-type> could be any of the following:
 //   - string, bool, []byte, int64, float32, float64, strfmt.Date, strfmt.DateTime,
-//     strfmt.UUID, interface{}, or map[string]interface{}.
+//     strfmt.UUID, interface{} (any), or map[string]interface{} (any object).
 //
 // Example:
 // type MyStruct struct {

--- a/v5/core/unmarshal_v2.go
+++ b/v5/core/unmarshal_v2.go
@@ -23,14 +23,13 @@ import (
 )
 
 const (
-	errorPropertyInsert          = " property '%s' as"
-	errorPropertyNameMissing     = "the 'propertyName' parameter is required"
-	errorUnmarshalPrimitive      = "error unmarshalling property '%s': %s"
-	errorUnmarshalModel          = "error unmarshalling%s %s: %s"
-	errorIncorrectInputType      = "expected 'rawInput' to be a %s but was %s"
-	errorUnsupportedMapEntryType = "unsupported map entry type: %s"
-	errorUnsupportedResultType   = "unsupported 'result' type: %s"
-	errorUnmarshallInputIsNil    = "input to unmarshall is nil"
+	errorPropertyInsert        = " property '%s' as"
+	errorPropertyNameMissing   = "the 'propertyName' parameter is required"
+	errorUnmarshalPrimitive    = "error unmarshalling property '%s': %s"
+	errorUnmarshalModel        = "error unmarshalling%s %s: %s"
+	errorIncorrectInputType    = "expected 'rawInput' to be a %s but was %s"
+	errorUnsupportedResultType = "unsupported 'result' type: %s"
+	errorUnmarshallInputIsNil  = "input to unmarshall is nil"
 )
 
 //
@@ -121,6 +120,7 @@ type ModelUnmarshaller func(rawInput map[string]json.RawMessage, result interfac
 // result: the unmarshal destination.  This should be passed in as one of the following types of values:
 //   - **<model> (a ptr to a ptr to a <model> instance)
 //   - *[]<model> (a ptr to a <model> slice)
+//   - *[][]<model> (a ptr to a slice of <model> slices)
 //   - *map[string]<model> (a ptr to a map of <model> instances)
 //   - *map[string][]<model> (a ptr to a map of <model> slices)
 //
@@ -145,6 +145,13 @@ type ModelUnmarshaller func(rawInput map[string]json.RawMessage, result interfac
 // *[]Foo             | != "" (e.g. "prop")      | a map[string]json.RawMessage and rawInput["prop"]
 //                    |                          | contains a []Foo (slice of Foo instances)
 // -------------------+--------------------------+------------------------------------------------------------------
+// *[][]Foo           | == ""                    | a []json.RawMessage where each slice element contains
+//                    |                          | a []Foo (i.e. the json.RawMessage can be unmarshalled
+//                    |                          | into a []Foo)
+//                    |                          |
+// *[][]Foo           | != "" (e.g. "prop")      | a map[string]json.RawMessage and rawInput["prop"]
+//                    |                          | contains a [][]Foo (slice of Foo slices)
+// -------------------+--------------------------+------------------------------------------------------------------
 // *map[string]Foo    | == ""                    | a map[string]json.RawMessage which directly contains the
 //                    |                          | map[string]Foo (i.e. the value within each entry in 'rawInput'
 //                    |                          | contains an instance of Foo)
@@ -160,7 +167,7 @@ type ModelUnmarshaller func(rawInput map[string]json.RawMessage, result interfac
 // -------------------+--------------------------+------------------------------------------------------------------
 func UnmarshalModel(rawInput interface{}, propertyName string, result interface{}, unmarshaller ModelUnmarshaller) (err error) {
 
-	// Make sure some input is provided. Otherwise return an error
+	// Make sure some input is provided. Otherwise return an error.
 	if IsNil(rawInput) {
 		err = fmt.Errorf(errorUnmarshallInputIsNil)
 		return
@@ -174,25 +181,62 @@ func UnmarshalModel(rawInput interface{}, propertyName string, result interface{
 	case reflect.Ptr, reflect.Interface:
 		// Unmarshal a single instance of a model.
 		err = unmarshalModelInstance(rawInput, propertyName, result, unmarshaller)
+
 	case reflect.Slice:
-		// Unmarshal a slice of model instances.
-		err = unmarshalModelSlice(rawInput, propertyName, result, unmarshaller)
+		// For a slice, we need to look at the slice element type.
+		rElementType := rResultType.Elem()
+		switch rElementType.Kind() {
+		case reflect.Struct, reflect.Interface:
+			// A []<model>
+			// Slice element type is struct or intf, so must be a slice of model instances.
+			// Unmarshal a slice of model instances.
+			err = unmarshalModelSlice(rawInput, propertyName, result, unmarshaller)
+
+		case reflect.Slice:
+			// If the slice element type is slice (i.e. a slice of slices),
+			// then we need to make sure that the inner slice's element type is a model (struct or intf).
+			rInnerElementType := rElementType.Elem()
+			switch rInnerElementType.Kind() {
+			case reflect.Struct, reflect.Interface:
+				// A [][]<model>
+				err = unmarshalModelSliceSlice(rawInput, propertyName, result, unmarshaller)
+
+			default:
+				err = fmt.Errorf(errorUnsupportedResultType, rResultType.String())
+			}
+
+		default:
+			err = fmt.Errorf(errorUnsupportedResultType, rResultType.String())
+			return
+		}
+
 	case reflect.Map:
 		// For a map, we need to look at the map entry type.
-		rEntryType := reflect.TypeOf(result).Elem().Elem()
+		// We currently support map[string]<model> and map[string][]<model>.
+		rEntryType := rResultType.Elem()
 		switch rEntryType.Kind() {
 		case reflect.Struct, reflect.Interface:
 			// A map[string]<model>
 			err = unmarshalModelMap(rawInput, propertyName, result, unmarshaller)
 		case reflect.Slice:
-			// A map[string][]<model>
-			err = unmarshalModelSliceMap(rawInput, propertyName, result, unmarshaller)
+			// If the map entry type is a slice, make sure it is a slice of model instances.
+			rElementType := rEntryType.Elem()
+			switch rElementType.Kind() {
+			case reflect.Struct, reflect.Interface:
+				// A map[string][]<model>
+				err = unmarshalModelSliceMap(rawInput, propertyName, result, unmarshaller)
+
+			default:
+				err = fmt.Errorf(errorUnsupportedResultType, rResultType.String())
+				return
+			}
 		default:
-			err = fmt.Errorf(errorUnsupportedMapEntryType, reflect.TypeOf(result).Elem().Elem().String())
+			err = fmt.Errorf(errorUnsupportedResultType, rResultType.String())
 			return
 		}
+
 	default:
-		err = fmt.Errorf(errorUnsupportedResultType, reflect.TypeOf(result).Elem().String())
+		err = fmt.Errorf(errorUnsupportedResultType, rResultType.String())
 		return
 	}
 	return
@@ -219,11 +263,14 @@ func unmarshalModelInstance(rawInput interface{}, propertyName string, result in
 	var foundInput bool
 
 	// Obtain the unmarshal input source from 'rawInput'.
-	foundInput, rawMap, err = getUnmarshalInputSource(rawInput, propertyName)
+	foundInput, rawMap, err = getUnmarshalInputSourceMap(rawInput, propertyName)
 	if err != nil {
 		err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName), getModelResultType(result), err.Error())
 		return
 	}
+
+	// At this point, 'rawMap' should be the map[string]json.RawMessage which represents model instance:
+	// i.e. rawMap --> `{ "prop1": "value1", "prop2": "value2", ...}"
 
 	// Initialize our result to nil.
 	// Note: 'result' is a ptr to a ptr to a model struct.
@@ -243,7 +290,7 @@ func unmarshalModelInstance(rawInput interface{}, propertyName string, result in
 }
 
 //
-// unmarshalModelSlice unmarshals 'rawInput' into a slice of model instances.
+// unmarshalModelSlice unmarshals 'rawInput' into a []<model>.
 //
 // Parameters:
 //
@@ -268,60 +315,35 @@ func unmarshalModelInstance(rawInput interface{}, propertyName string, result in
 //
 func unmarshalModelSlice(rawInput interface{}, propertyName string, result interface{}, unmarshaller ModelUnmarshaller) (err error) {
 	var rawSlice []json.RawMessage
-	var foundIt bool
+	var foundInput bool
 
-	// If propertyName was specified, then retrieve that entry from 'rawInput' as our unmarshal input source.
-	// Otherwise, just use 'rawInput' directly.
-	if propertyName != "" {
-		rawMap, ok := rawInput.(map[string]json.RawMessage)
-		if !ok {
-			causedBy := fmt.Errorf(errorIncorrectInputType, "map[string][]json.RawMessage",
-				reflect.TypeOf(rawInput).String())
-			err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
-				reflect.TypeOf(result).Elem().String(), causedBy.Error())
-			return
-		}
-
-		var rawMsg json.RawMessage
-		rawMsg, foundIt = rawMap[propertyName]
-
-		// If we didn't find the property containing the JSON input, then bail out now.
-		if !foundIt || isJsonNull(rawMsg) {
-			return
-		} else {
-			err = json.Unmarshal(rawMsg, &rawSlice)
-			if err != nil {
-				causedBy := fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
-					reflect.TypeOf(result).Elem().String(), err.Error())
-				err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
-					reflect.TypeOf(result).Elem().String(), causedBy.Error())
-				return
-			}
-		}
-	} else {
-		var ok bool
-		rawSlice, ok = rawInput.([]json.RawMessage)
-		if !ok {
-			causedBy := fmt.Errorf(errorIncorrectInputType, "[]json.RawMessage", reflect.TypeOf(rawInput).String())
-			err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
-				reflect.TypeOf(result).Elem().String(), causedBy.Error())
-			return
-		}
-		foundIt = true
+	// Obtain the unmarshal input source from 'rawInput'.
+	foundInput, rawSlice, err = getUnmarshalInputSourceSlice(rawInput, propertyName)
+	if err != nil {
+		err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
+			reflect.TypeOf(result).Elem().String(), err.Error())
+		return
 	}
+
+	if !foundInput {
+		return
+	}
+
+	// At this point, 'rawSlice' should be the []json.RawMessage which represents the slice of model instances:
+	// i.e. rawSlice --> "[ {...}, {...}, ...]"
+
+	// 'sliceSize' is the number of elements found in 'rawSlice'.
+	// if 'rawSlice' is nil, 'sliceSize' will be 0, which is what we want.
+	sliceSize := len(rawSlice)
 
 	// Get a reflective view of the result and initialize it.
-	var sliceSize int = 0
-	if foundIt {
-		sliceSize = len(rawSlice)
-	}
 	rResultSlice := reflect.ValueOf(result).Elem()
 	rResultSlice.Set(reflect.MakeSlice(reflect.TypeOf(result).Elem(), 0, sliceSize))
 
-	// If there is an unmarshal input source, then unmarshal it.
-	if foundIt && rawSlice != nil {
+	// If there is anything to unmarshal, then unmarshal it.
+	if sliceSize > 0 {
 		// Determine the type of the 'result' parameter that we'll need to pass to
-		// the model-specific unmarshaller.
+		// the model-specific unmarshaller (i.e. a *Foo).
 		var receiverType reflect.Type
 		receiverType, err = getUnmarshalResultType(result)
 		if err != nil {
@@ -358,13 +380,88 @@ func unmarshalModelSlice(rawInput interface{}, propertyName string, result inter
 	return
 }
 
-// isJsonNull returns true iff 'rawMsg' is exlicitly nil or contains a JSON "null" value.
-func isJsonNull(rawMsg json.RawMessage) bool {
-	var nullLiteral = []byte("null")
-	if rawMsg == nil || string(rawMsg) == string(nullLiteral) {
-		return true
+//
+// unmarshalModelSliceSlice unmarshals 'rawInput' into a [][]<model>.
+//
+// Parameters:
+//
+// rawInput: is the unmarshal input source, and should be one of the following:
+// 1. a map[string]json.RawMessage - in this case 'propertyName' should specify the name
+// of the property to retrieve from the map to obtain the []json.RawMessage containing the slice of model slices
+// to be unmarshalled.
+//
+// 2. a []json.RawMessage - in this case, 'propertyName' should be specified as "" to indicate that
+// the []json.RawMessage is available directly via the 'rawInput' parameter.
+//
+// propertyName: an optional name of a property to be retrieved from 'rawInput'.
+// If 'propertyName' is specified as a non-empty string, then 'rawInput' is assumed to be a map[string]json.RawMessage,
+// and the named property is retrieved to obtain the []json.RawMessage to be unmarshalled.
+// If 'propertyName' is specified as "", then 'rawInput' is assumed to be a []json.RawMessage and is used directly
+// as the unmarshal input source.
+//
+// result: this should be a pointer to a slice of model slices (e.g. *[][]Foo for model type Foo).
+// This function will construct a new slice of slices and return it through 'result'.
+//
+// 'unmarshaller' is the function used to unmarshal a single instance of the model.
+//
+func unmarshalModelSliceSlice(rawInput interface{}, propertyName string, result interface{}, unmarshaller ModelUnmarshaller) (err error) {
+	var rawSlice []json.RawMessage
+	var foundInput bool
+
+	// Obtain the unmarshal input source from 'rawInput'.
+	foundInput, rawSlice, err = getUnmarshalInputSourceSlice(rawInput, propertyName)
+	if err != nil {
+		err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
+			reflect.TypeOf(result).Elem().String(), err.Error())
+		return
 	}
-	return false
+
+	if !foundInput {
+		return
+	}
+
+	// At this point, 'rawSlice' should be the []json.RawMessage which represents the overall slice whose
+	// elements should be slices of model instances:
+	// rawSlice --> "[ [{}, {},...], [{}, {},...], ...]"
+
+	// Get a reflective view of the result and initialize it.
+	// This will be a slice of slices.
+	sliceSize := len(rawSlice)
+
+	rResultSlice := reflect.ValueOf(result).Elem()
+	rResultSlice.Set(reflect.MakeSlice(reflect.TypeOf(result).Elem(), 0, sliceSize))
+
+	// If there is an unmarshal input source, then unmarshal it.
+	if sliceSize > 0 {
+		for _, rawMsg := range rawSlice {
+			// Make sure our inner slice raw message isn't an explicit JSON null value.
+			// Each value in 'rawMap' should contain an instance of []<model>.
+			// We'll first unmarshal each value into a []jsonRawMessage, then unmarshal that
+			// into a []<model> using unmarshalModelSlice.
+			var innerRawSlice []json.RawMessage
+			err = json.Unmarshal(rawMsg, &innerRawSlice)
+			if err != nil {
+				err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
+					reflect.TypeOf(result).Elem().String(), err.Error())
+				return
+			}
+
+			// Construct a slice of the correct type (i.e. []Foo)
+			rSliceValue := reflect.New(reflect.TypeOf(result).Elem().Elem())
+
+			// Unmarshal 'innerRawSlice' into a slice of models.
+			err = unmarshalModelSlice(innerRawSlice, "", rSliceValue.Interface(), unmarshaller)
+			if err != nil {
+				err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
+					reflect.TypeOf(result).Elem().String(), err.Error())
+				return
+			}
+
+			// Now add the unmarshalled model slice to the result slice (reflectively, of course :) ).
+			rResultSlice.Set(reflect.Append(rResultSlice, rSliceValue.Elem()))
+		}
+	}
+	return
 }
 
 //
@@ -389,7 +486,7 @@ func unmarshalModelMap(rawInput interface{}, propertyName string, result interfa
 	var foundInput bool
 
 	// Obtain the unmarshal input source from 'rawInput'.
-	foundInput, rawMap, err = getUnmarshalInputSource(rawInput, propertyName)
+	foundInput, rawMap, err = getUnmarshalInputSourceMap(rawInput, propertyName)
 	if err != nil {
 		err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
 			reflect.TypeOf(result).Elem().String(), err.Error())
@@ -468,7 +565,7 @@ func unmarshalModelSliceMap(rawInput interface{}, propertyName string, result in
 	var foundInput bool
 
 	// Obtain the unmarshal input source from 'rawInput'.
-	foundInput, rawMap, err = getUnmarshalInputSource(rawInput, propertyName)
+	foundInput, rawMap, err = getUnmarshalInputSourceMap(rawInput, propertyName)
 	if err != nil {
 		err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
 			reflect.TypeOf(result).Elem().String(), err.Error())
@@ -519,7 +616,7 @@ func unmarshalModelSliceMap(rawInput interface{}, propertyName string, result in
 }
 
 //
-// getUnmarshalInputSource is a utility function that will return the appropriate unmarshal input source from 'rawInput'
+// getUnmarshalInputSourceMap returns the appropriate unmarshal input source from 'rawInput'
 // in the form of a map[string]json.RawMessage.
 //
 // Parameters:
@@ -528,7 +625,7 @@ func unmarshalModelSliceMap(rawInput interface{}, propertyName string, result in
 // propertyName: (optional) the name of the property (map entry) within 'rawInput' that contains the
 // unmarshal input source.  If specified as "", then 'rawInput' is assumed to contain the entire input source directly.
 //
-func getUnmarshalInputSource(rawInput interface{}, propertyName string) (foundInput bool, inputSource map[string]json.RawMessage, err error) {
+func getUnmarshalInputSourceMap(rawInput interface{}, propertyName string) (foundInput bool, inputSource map[string]json.RawMessage, err error) {
 	foundInput = true
 
 	// rawInput should be a map[string]json.RawMessage.
@@ -560,6 +657,72 @@ func getUnmarshalInputSource(rawInput interface{}, propertyName string) (foundIn
 	return
 }
 
+//
+// getUnmarshalInputSourceSlice returns the appropriate unmarshal input source from 'rawInput'
+// in the form of a []json.RawMessage.
+//
+// Parameters:
+// rawInput: the raw unmarshalled input.  This should be in the form of a map[string]json.RawMessage or []json.RawMessage,
+// depending on the value of propertyName.
+//
+// propertyName: (optional) the name of the property (map entry) within 'rawInput' that contains the
+// unmarshal input source.  The specified map entry should contain a []json.RawMessage which
+// will be used as the unmarshal input source. If 'propertyName' is specified as "", then 'rawInput'
+// is assumed to be a []json.RawMessage and contains the entire input source directly.
+//
+func getUnmarshalInputSourceSlice(rawInput interface{}, propertyName string) (foundInput bool, inputSource []json.RawMessage, err error) {
+	// If propertyName was specified, then retrieve that entry from 'rawInput' (assumed to be a map[string]json.RawMessage)
+	// as our unmarshal input source.  Otherwise, just use 'rawInput' directly.
+	if propertyName != "" {
+		rawMap, ok := rawInput.(map[string]json.RawMessage)
+		if !ok {
+			err = fmt.Errorf(errorIncorrectInputType, "map[string]json.RawMessage", reflect.TypeOf(rawInput).String())
+			return
+		}
+
+		var rawMsg json.RawMessage
+		rawMsg, ok = rawMap[propertyName]
+
+		// If we didn't find the property containing the JSON input, then bail out now.
+		if !ok || isJsonNull(rawMsg) {
+			return
+		} else {
+			// We found the property in the map, so unmarshal the json.RawMessage into a []json.RawMessage
+			var rawSlice = make([]json.RawMessage, 0)
+			err = json.Unmarshal(rawMsg, &rawSlice)
+			if err != nil {
+				err = fmt.Errorf(errorIncorrectInputType, "map[string][]json.RawMessage", reflect.TypeOf(rawInput).String())
+				return
+			}
+
+			foundInput = true
+			inputSource = rawSlice
+		}
+	} else {
+		// 'propertyName' was not specified, so 'rawInput' should be our []json.RawMessage input source.
+
+		rawSlice, ok := rawInput.([]json.RawMessage)
+		if !ok {
+			err = fmt.Errorf(errorIncorrectInputType, "[]json.RawMessage", reflect.TypeOf(rawInput).String())
+			return
+		}
+
+		foundInput = true
+		inputSource = rawSlice
+	}
+
+	return
+}
+
+// isJsonNull returns true iff 'rawMsg' is exlicitly nil or contains a JSON "null" value.
+func isJsonNull(rawMsg json.RawMessage) bool {
+	var nullLiteral = []byte("null")
+	if rawMsg == nil || string(rawMsg) == string(nullLiteral) {
+		return true
+	}
+	return false
+}
+
 // propInsert is a utility function used to optionally include the name of a property in an error message.
 func propInsert(propertyName string) string {
 	if propertyName != "" {
@@ -572,11 +735,14 @@ func propInsert(propertyName string) string {
 // The resulting type can be constructed with the reflect.New() function.
 func getUnmarshalResultType(result interface{}) (ptrType reflect.Type, err error) {
 	rResultType := reflect.TypeOf(result).Elem().Elem()
-	if rResultType.Kind() == reflect.Struct {
+	switch rResultType.Kind() {
+	case reflect.Struct, reflect.Slice:
 		ptrType = reflect.PtrTo(rResultType)
-	} else if rResultType.Kind() == reflect.Interface {
+
+	case reflect.Interface:
 		ptrType = rResultType
-	} else {
+
+	default:
 		err = fmt.Errorf(errorUnsupportedResultType, rResultType.String())
 	}
 	return

--- a/v5/core/unmarshal_v2_models_test.go
+++ b/v5/core/unmarshal_v2_models_test.go
@@ -28,12 +28,26 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// This simulates a generated model with its unmarshal function.
+// MyModel simulates a generated model with its unmarshal function.
 type MyModel struct {
 	Foo *string `json:"foo" validate:"required"`
 	Bar *int64  `json:"bar" validate:"required"`
 }
 
+// AssertEqual asserts that 'm' is equivalent to 'this'.
+func (this MyModel) AssertEqual(t *testing.T, m MyModel) {
+	assert.True(t, (this.Foo == nil && m.Foo == nil) || (this.Foo != nil && m.Foo != nil && *this.Foo == *m.Foo))
+	assert.True(t, (this.Bar == nil && m.Bar == nil) || (this.Bar != nil && m.Bar != nil && *this.Bar == *m.Bar))
+}
+
+// Instances of MyModel used in the tests below.
+var myModel1 MyModel = MyModel{Foo: StringPtr("string1"), Bar: Int64Ptr(44)}
+var myModel2 MyModel = MyModel{Foo: StringPtr("string2"), Bar: Int64Ptr(74)}
+var myModel3 MyModel = MyModel{Foo: StringPtr("string3"), Bar: Int64Ptr(33)}
+var myModel4 MyModel = MyModel{Foo: StringPtr("string4"), Bar: Int64Ptr(21)}
+var myModelZeroValue MyModel
+
+// Simulated "generated" unmarshal function for MyModel struct.
 func UnmarshalMyModel(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(MyModel)
 	err = UnmarshalPrimitive(m, "foo", &obj.Foo)
@@ -48,14 +62,16 @@ func UnmarshalMyModel(m map[string]json.RawMessage, result interface{}) (err err
 	return
 }
 
-// This simulates a generated model with properties that involve models, along with its unmarshal function.
+// ModelStruct simulates a generated model with properties that involve models, along with its unmarshal function.
 type ModelStruct struct {
-	Model         *MyModel             `json:"model" validate:"required"`
-	ModelSlice    []MyModel            `json:"model_slice" validate:"required"`
-	ModelMap      map[string]MyModel   `json:"model_map" validate:"required"`
-	ModelSliceMap map[string][]MyModel `json:"model_slice_map" validate:"required"`
+	Model           *MyModel             `json:"model" validate:"required"`
+	ModelSlice      []MyModel            `json:"model_slice" validate:"required"`
+	ModelMap        map[string]MyModel   `json:"model_map" validate:"required"`
+	ModelSliceMap   map[string][]MyModel `json:"model_slice_map" validate:"required"`
+	ModelSliceSlice [][]MyModel          `json:"model_slice_slice" validate:"required"`
 }
 
+// Simulated "generated" unmarshal function for ModelStruct struct.
 func UnmarshalModelStruct(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(ModelStruct)
 	err = UnmarshalModel(m, "model", &obj.Model, UnmarshalMyModel)
@@ -74,11 +90,15 @@ func UnmarshalModelStruct(m map[string]json.RawMessage, result interface{}) (err
 	if err != nil {
 		return
 	}
+	err = UnmarshalModel(m, "model_slice_slice", &obj.ModelSliceSlice, UnmarshalMyModel)
+	if err != nil {
+		return
+	}
 	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
 	return
 }
 
-// This simulates a "parent" struct (interface) with a discriminator along with one "substruct" and their unmarshal functions.
+// VehicleIntf simulates a "parent" struct (interface) with a discriminator along with one "substruct" and their unmarshal functions.
 // The Vehicle struct is not defined here because the linter informed me that it wasn't being used :)
 type VehicleIntf interface {
 	isaVehicle() bool
@@ -102,15 +122,27 @@ func UnmarshalVehicle(m map[string]json.RawMessage, result interface{}) (err err
 	return
 }
 
+// Car serves as a discriminated subclass (substruct?) of Vehicle.
 type Car struct {
 	VehicleType *string `json:"vehicle_type" validate:"required"`
 	Make        *string `json:"make,omitempty"`
 	BodyStyle   *string `json:"body_style,omitempty"`
 }
 
+// AssertEqual asserts that 'c' is equivalent to 'this'.
+func (this Car) AssertEqual(t *testing.T, c Car) {
+	assert.True(t, (this.VehicleType == nil && c.VehicleType == nil) || (this.VehicleType != nil && c.VehicleType != nil && *this.VehicleType == *c.VehicleType))
+	assert.True(t, (this.Make == nil && c.Make == nil) || (this.Make != nil && c.Make != nil && *this.Make == *c.Make))
+	assert.True(t, (this.BodyStyle == nil && c.BodyStyle == nil) || (this.BodyStyle != nil && c.BodyStyle != nil && *this.BodyStyle == *c.BodyStyle))
+}
+
+// Instance of Car used in tests below.
+var car1 Car = Car{VehicleType: StringPtr("Car"), Make: StringPtr("Ford"), BodyStyle: StringPtr("Coupe")}
+
 func (*Car) isaVehicle() bool {
 	return true
 }
+
 func UnmarshalCar(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(Car)
 	err = UnmarshalPrimitive(m, "vehicle_type", &obj.VehicleType)
@@ -129,15 +161,19 @@ func UnmarshalCar(m map[string]json.RawMessage, result interface{}) (err error) 
 	return
 }
 
-func TestUnmarshalModelInstanceNil(t *testing.T) {
-	jsonString := `{ 
-		"null_model": null,
-		"empty_model": { }
-	}`
-	rawMap := unmarshalMap(jsonString)
+//
+// Test methods.
+//
 
+func TestUnmarshalModelInstanceNil(t *testing.T) {
 	var err error
 	var myModel *MyModel
+
+	jsonString := `{ 
+		"null_model": null,
+		"empty_model": {}
+	}`
+	rawMap := unmarshalMap(jsonString)
 
 	// Unmarshal a missing property.
 	myModel = nil
@@ -156,39 +192,41 @@ func TestUnmarshalModelInstanceNil(t *testing.T) {
 	err = UnmarshalModel(rawMap, "empty_model", &myModel, UnmarshalMyModel)
 	assert.Nil(t, err)
 	assert.NotNil(t, myModel)
-	assert.Nil(t, myModel.Foo)
-	assert.Nil(t, myModel.Bar)
+	myModelZeroValue.AssertEqual(t, *myModel)
 }
 
 func TestUnmarshalModelInstance(t *testing.T) {
-	jsonString := `{ "foo": "string1", "bar": 44 }`
-
 	var err error
-	var myModel *MyModel
+	var actualModel *MyModel
+
+	jsonString := toJSON(myModel1)
+	rawMap := unmarshalMap(jsonString)
 
 	// Unmarshal an instance of the model.
-	rawMap := unmarshalMap(jsonString)
-	err = UnmarshalModel(rawMap, "", &myModel, UnmarshalMyModel)
+	err = UnmarshalModel(rawMap, "", &actualModel, UnmarshalMyModel)
 	assert.Nil(t, err)
-	assert.NotNil(t, myModel)
-	assert.Equal(t, "string1", *(myModel.Foo))
-	assert.Equal(t, int64(44), *(myModel.Bar))
+	assert.NotNil(t, actualModel)
+	myModel1.AssertEqual(t, *actualModel)
 
 	// Unmarshal with "zero" input should return an error
 	var zeroRawMap map[string]json.RawMessage
-	err = UnmarshalModel(zeroRawMap, "", &myModel, UnmarshalMyModel)
+	actualModel = nil
+	err = UnmarshalModel(zeroRawMap, "", &actualModel, UnmarshalMyModel)
 	assert.NotNil(t, err)
+	assert.Nil(t, actualModel)
 }
 
 func TestUnmarshalModelSliceNil(t *testing.T) {
-	jsonString := `{ 
-		"null_slice": null,
-		"empty_slice": []
-	}`
-	rawMap := unmarshalMap(jsonString)
-
 	var err error
 	var mySlice []MyModel
+
+	jsonTemplate := `{ 
+		"null_slice": null,
+		"empty_slice": [],
+		"slice_with_null": [ null, %m1, null ]
+	}`
+	jsonString := strings.ReplaceAll(jsonTemplate, "%m1", toJSON(myModel1))
+	rawMap := unmarshalMap(jsonString)
 
 	// Unmarshal a missing property.
 	mySlice = nil
@@ -210,38 +248,154 @@ func TestUnmarshalModelSliceNil(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, mySlice)
 	assert.Equal(t, 0, len(mySlice))
+
+	// Unmarshal a slice with a null value.
+	mySlice = nil
+	err = UnmarshalModel(rawMap, "slice_with_null", &mySlice, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.NotNil(t, mySlice)
+	assert.Equal(t, 3, len(mySlice))
+	myModelZeroValue.AssertEqual(t, mySlice[0])
+	myModel1.AssertEqual(t, mySlice[1])
+	myModelZeroValue.AssertEqual(t, mySlice[2])
 }
 
 func TestUnmarshalModelSlice(t *testing.T) {
-	jsonString := `[ { "foo": "string1", "bar": 44 }, { "foo": "string2", "bar": 74 } ]`
 	var err error
 	var mySlice []MyModel
 
-	// Unmarshal a model slice.
+	jsonTemplate := `[ %m1, %m2 ]`
+	jsonString := strings.ReplaceAll(jsonTemplate, "%m1", toJSON(myModel1))
+	jsonString = strings.ReplaceAll(jsonString, "%m2", toJSON(myModel2))
 	rawSlice := unmarshalSlice(jsonString)
+
+	// Unmarshal a model slice.
 	err = UnmarshalModel(rawSlice, "", &mySlice, UnmarshalMyModel)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(mySlice))
-	assert.Equal(t, "string1", *(mySlice[0].Foo))
-	assert.Equal(t, int64(44), *(mySlice[0].Bar))
-	assert.Equal(t, "string2", *(mySlice[1].Foo))
-	assert.Equal(t, int64(74), *(mySlice[1].Bar))
+	myModel1.AssertEqual(t, mySlice[0])
+	myModel2.AssertEqual(t, mySlice[1])
 
 	// Unmarshal with "zero" input should return an error
 	var zeroSlice []json.RawMessage
+	mySlice = nil
 	err = UnmarshalModel(zeroSlice, "", &mySlice, UnmarshalMyModel)
 	assert.NotNil(t, err)
+	assert.Nil(t, mySlice)
+}
+
+func TestUnmarshalModelSliceSliceNil(t *testing.T) {
+	var err error
+	var mySlice [][]MyModel
+
+	jsonTemplate := `{ 
+		"null_slice": null,
+		"empty_slice": [],
+		"slice_with_null1": [ null ],
+		"slice_with_null2": [ null, [ null, %m1, null ], null ]
+	}`
+	jsonString := strings.ReplaceAll(jsonTemplate, "%m1", toJSON(myModel1))
+	rawMap := unmarshalMap(jsonString)
+
+	// Unmarshal a missing property.
+	mySlice = nil
+	err = UnmarshalModel(rawMap, "missing_slice", &mySlice, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.Nil(t, mySlice)
+	assert.Equal(t, 0, len(mySlice))
+
+	// Unmarshal an explicit null value.
+	mySlice = nil
+	err = UnmarshalModel(rawMap, "null_slice", &mySlice, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.Nil(t, mySlice)
+	assert.Equal(t, 0, len(mySlice))
+
+	// Unmarshal an empty slice.
+	mySlice = nil
+	err = UnmarshalModel(rawMap, "empty_slice", &mySlice, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.NotNil(t, mySlice)
+	assert.Equal(t, 0, len(mySlice))
+
+	// Unmarshal slice with "null" inner slice.
+	mySlice = nil
+	err = UnmarshalModel(rawMap, "slice_with_null1", &mySlice, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.NotNil(t, mySlice)
+	assert.Equal(t, 1, len(mySlice))
+	assert.Equal(t, 0, len(mySlice[0]))
+
+	// Unmarshal slice with nulls within the inner slices.
+	mySlice = nil
+	err = UnmarshalModel(rawMap, "slice_with_null2", &mySlice, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.NotNil(t, mySlice)
+
+	// Outer slice should have 3 elements.
+	assert.Equal(t, 3, len(mySlice))
+
+	// The first inner slice should be empty.
+	assert.Equal(t, 0, len(mySlice[0]))
+
+	// The second inner slice should have 3 elements.
+	assert.Equal(t, 3, len(mySlice[1]))
+	myModelZeroValue.AssertEqual(t, mySlice[1][0])
+	myModel1.AssertEqual(t, mySlice[1][1])
+	myModelZeroValue.AssertEqual(t, mySlice[1][2])
+
+	// The third inner slice should be empty.
+	assert.Equal(t, 0, len(mySlice[2]))
+}
+
+func TestUnmarshalModelSliceSlice(t *testing.T) {
+	var err error
+	var mySlice [][]MyModel
+
+	jsonTemplate := `[ [ %m1, %m2 ], [ %m3, %m4, %m2, %m1], [ %m4, {} ] ]`
+	jsonString := strings.ReplaceAll(jsonTemplate, "%m1", toJSON(myModel1))
+	jsonString = strings.ReplaceAll(jsonString, "%m2", toJSON(myModel2))
+	jsonString = strings.ReplaceAll(jsonString, "%m3", toJSON(myModel3))
+	jsonString = strings.ReplaceAll(jsonString, "%m4", toJSON(myModel4))
+	rawSlice := unmarshalSlice(jsonString)
+
+	// Unmarshal the slice of model slices.
+	err = UnmarshalModel(rawSlice, "", &mySlice, UnmarshalMyModel)
+	assert.Nil(t, err)
+
+	// Outer slice should have 3 elements.
+	assert.Equal(t, 3, len(mySlice))
+
+	// The first inner slice should have 2 elements.
+	assert.Equal(t, 2, len(mySlice[0]))
+	myModel1.AssertEqual(t, mySlice[0][0])
+	myModel2.AssertEqual(t, mySlice[0][1])
+
+	// The second inner slice should have 4 elements.
+	assert.Equal(t, 4, len(mySlice[1]))
+	myModel3.AssertEqual(t, mySlice[1][0])
+	myModel4.AssertEqual(t, mySlice[1][1])
+	myModel2.AssertEqual(t, mySlice[1][2])
+	myModel1.AssertEqual(t, mySlice[1][3])
+
+	// The third inner slice should ahve 2 elements.
+	assert.Equal(t, 2, len(mySlice[2]))
+	myModel4.AssertEqual(t, mySlice[2][0])
+	myModelZeroValue.AssertEqual(t, mySlice[2][1])
 }
 
 func TestUnmarshalModelMapNil(t *testing.T) {
-	jsonString := `{ 
-		"null_map": null,
-		"empty_map": { }
-	}`
-	rawMap := unmarshalMap(jsonString)
-
 	var err error
 	var myMap map[string]MyModel
+
+	jsonString := `{ 
+		"null_map": null,
+		"empty_map": {},
+		"map_with_null": { 
+			"model1": null 
+		}
+	}`
+	rawMap := unmarshalMap(jsonString)
 
 	// Unmarshal a missing property.
 	myMap = nil
@@ -263,47 +417,63 @@ func TestUnmarshalModelMapNil(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, myMap)
 	assert.Equal(t, 0, len(myMap))
+
+	// Unmarshal a map with a null entry.
+	myMap = nil
+	err = UnmarshalModel(rawMap, "map_with_null", &myMap, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.NotNil(t, myMap)
+	assert.Equal(t, 1, len(myMap))
+	assert.NotNil(t, myMap["model1"])
+	myModelZeroValue.AssertEqual(t, myMap["model1"])
 }
 
 func TestUnmarshalModelMap(t *testing.T) {
-	jsonString := `{
-		"model1": { "foo": "string1", "bar": 44 }, 
-		"model2": { "foo": "string2", "bar": 74 }
-	}`
 	var err error
 	var myMap map[string]MyModel
 
-	// Unmarshal a model map.
+	jsonTemplate := `{
+		"model1": %m1, 
+		"model2": %m2
+	}`
+	jsonString := strings.ReplaceAll(jsonTemplate, "%m1", toJSON(myModel1))
+	jsonString = strings.ReplaceAll(jsonString, "%m2", toJSON(myModel2))
 	rawMap := unmarshalMap(jsonString)
+
+	// Unmarshal a map of model instances.
 	err = UnmarshalModel(rawMap, "", &myMap, UnmarshalMyModel)
 	assert.Nil(t, err)
+	assert.NotNil(t, myMap)
 	assert.Equal(t, 2, len(myMap))
+
 	assert.NotNil(t, myMap["model1"])
+	myModel1.AssertEqual(t, myMap["model1"])
+
 	assert.NotNil(t, myMap["model2"])
+	myModel2.AssertEqual(t, myMap["model2"])
 
 	_, foundIt := myMap["bad_key"]
 	assert.False(t, foundIt)
-
-	assert.Equal(t, "string1", *(myMap["model1"].Foo))
-	assert.Equal(t, int64(44), *(myMap["model1"].Bar))
-	assert.Equal(t, "string2", *(myMap["model2"].Foo))
-	assert.Equal(t, int64(74), *(myMap["model2"].Bar))
 }
 
 func TestUnmarshalModelSliceMapNil(t *testing.T) {
+	var err error
+	var mySliceMap map[string][]MyModel
+
 	jsonString := `{ 
 		"null_prop": null, 
 		"empty_slice_map": { 
 			"empty_slice": [] 
 		},
-		"null_slice_map": { 
+		"map_with_null1": { 
 			"null_slice": null
+		},
+		"map_with_null2": {
+			"slice_with_null": [ null ]
 		}
+
 	}`
 	rawMap := unmarshalMap(jsonString)
-
-	var err error
-	var mySliceMap map[string][]MyModel
 
 	// Unmarshal a missing property.
 	mySliceMap = nil
@@ -324,206 +494,201 @@ func TestUnmarshalModelSliceMapNil(t *testing.T) {
 	err = UnmarshalModel(rawMap, "empty_slice_map", &mySliceMap, UnmarshalMyModel)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(mySliceMap))
+
 	assert.NotNil(t, mySliceMap["empty_slice"])
 	assert.Equal(t, 0, len(mySliceMap["empty_slice"]))
 
-	// Unmarshal a map with an explicit null slice. Result should be an empty map.
+	// Unmarshal a map with a "null" slice.
+	// Result should be an empty map.
 	mySliceMap = nil
-	err = UnmarshalModel(rawMap, "null_slice_map", &mySliceMap, UnmarshalMyModel)
+	err = UnmarshalModel(rawMap, "map_with_null1", &mySliceMap, UnmarshalMyModel)
 	assert.Nil(t, err)
 	assert.NotNil(t, mySliceMap)
 	assert.Equal(t, 0, len(mySliceMap))
-	assert.Nil(t, mySliceMap["null_slice"])
+
+	// Unmarshal a map with a slice that contains a "null" element.
+	// Result should be a map with a slice containing the model's zero value.
+	mySliceMap = nil
+	err = UnmarshalModel(rawMap, "map_with_null2", &mySliceMap, UnmarshalMyModel)
+	assert.Nil(t, err)
+	assert.NotNil(t, mySliceMap)
+	assert.Equal(t, 1, len(mySliceMap))
+
+	assert.NotNil(t, mySliceMap["slice_with_null"])
+	assert.Equal(t, 1, len(mySliceMap["slice_with_null"]))
+	myModelZeroValue.AssertEqual(t, mySliceMap["slice_with_null"][0])
 }
 
 func TestUnmarshalModelStruct(t *testing.T) {
-	m1 := `{ "foo": "string1", "bar": 44 }`
-	m2 := `{ "foo": "string2", "bar": 74 }`
-	m3 := `{ "foo": "string3", "bar": 33 }`
-	m4 := `{ "foo": "string4", "bar": 21 }`
+	var err error
+	var modelStruct *ModelStruct
+
 	jsonTemplate := `{
 		"model": %m1,
 		"model_slice": [ %m1, %m2 ],
 		"model_map": {
 			"model1": %m1,
-			"model2": %m2,
-			"model3": %m3,
-			"model4": %m4
+			"model2": %m2
 		},
 		"model_slice_map": {
 			"slice1": [ %m1, %m2, %m3 ],
 			"slice2": [ %m4 ]
-		}
+		},
+		"model_slice_slice": [ [ %m1, %m2 ], [ %m3 ], [ %m4, %m1 ]]
 	}`
-	jsonString := strings.ReplaceAll(jsonTemplate, "%m1", m1)
-	jsonString = strings.ReplaceAll(jsonString, "%m2", m2)
-	jsonString = strings.ReplaceAll(jsonString, "%m3", m3)
-	jsonString = strings.ReplaceAll(jsonString, "%m4", m4)
-
-	var err error
-	var modelStruct *ModelStruct
-
+	jsonString := strings.ReplaceAll(jsonTemplate, "%m1", toJSON(myModel1))
+	jsonString = strings.ReplaceAll(jsonString, "%m2", toJSON(myModel2))
+	jsonString = strings.ReplaceAll(jsonString, "%m3", toJSON(myModel3))
+	jsonString = strings.ReplaceAll(jsonString, "%m4", toJSON(myModel4))
 	rawMap := unmarshalMap(jsonString)
+
+	// Unmarshal the entire ModelStruct instance.
 	err = UnmarshalModel(rawMap, "", &modelStruct, UnmarshalModelStruct)
 	assert.Nil(t, err)
 	assert.NotNil(t, modelStruct)
-	assert.NotNil(t, modelStruct.Model)
-	assert.Equal(t, 2, len(modelStruct.ModelSlice))
-	assert.Equal(t, 4, len(modelStruct.ModelMap))
-	assert.Equal(t, 2, len(modelStruct.ModelSliceMap))
 
 	// Verify model instance.
-	assert.Equal(t, "string1", *(modelStruct.Model.Foo))
-	assert.Equal(t, int64(44), *(modelStruct.Model.Bar))
+	assert.NotNil(t, modelStruct.Model)
+	myModel1.AssertEqual(t, *modelStruct.Model)
 
 	// Verify model slice.
-	assert.Equal(t, "string1", *(modelStruct.ModelSlice[0].Foo))
-	assert.Equal(t, int64(44), *(modelStruct.ModelSlice[0].Bar))
-	assert.Equal(t, "string2", *(modelStruct.ModelSlice[1].Foo))
-	assert.Equal(t, int64(74), *(modelStruct.ModelSlice[1].Bar))
+	assert.Equal(t, 2, len(modelStruct.ModelSlice))
+	myModel1.AssertEqual(t, modelStruct.ModelSlice[0])
+	myModel2.AssertEqual(t, modelStruct.ModelSlice[1])
 
 	// Verify model map.
+	assert.Equal(t, 2, len(modelStruct.ModelMap))
 	assert.NotNil(t, modelStruct.ModelMap["model1"])
+	myModel1.AssertEqual(t, modelStruct.ModelMap["model1"])
 	assert.NotNil(t, modelStruct.ModelMap["model2"])
-	assert.NotNil(t, modelStruct.ModelMap["model3"])
-	assert.NotNil(t, modelStruct.ModelMap["model4"])
+	myModel2.AssertEqual(t, modelStruct.ModelMap["model2"])
 	_, foundIt := modelStruct.ModelMap["bad_key"]
 	assert.False(t, foundIt)
 
-	assert.Equal(t, "string1", *(modelStruct.ModelMap["model1"].Foo))
-	assert.Equal(t, int64(44), *(modelStruct.ModelMap["model1"].Bar))
-	assert.Equal(t, "string2", *(modelStruct.ModelMap["model2"].Foo))
-	assert.Equal(t, int64(74), *(modelStruct.ModelMap["model2"].Bar))
-	assert.Equal(t, "string3", *(modelStruct.ModelMap["model3"].Foo))
-	assert.Equal(t, int64(33), *(modelStruct.ModelMap["model3"].Bar))
-	assert.Equal(t, "string4", *(modelStruct.ModelMap["model4"].Foo))
-	assert.Equal(t, int64(21), *(modelStruct.ModelMap["model4"].Bar))
-
-	// Verify model slice map.
+	// Verify model slice map (map of model slices).
+	assert.Equal(t, 2, len(modelStruct.ModelSliceMap))
 	assert.NotNil(t, modelStruct.ModelSliceMap["slice1"])
 	assert.Equal(t, 3, len(modelStruct.ModelSliceMap["slice1"]))
+	myModel1.AssertEqual(t, modelStruct.ModelSliceMap["slice1"][0])
+	myModel2.AssertEqual(t, modelStruct.ModelSliceMap["slice1"][1])
+	myModel3.AssertEqual(t, modelStruct.ModelSliceMap["slice1"][2])
+
 	assert.NotNil(t, modelStruct.ModelSliceMap["slice2"])
 	assert.Equal(t, 1, len(modelStruct.ModelSliceMap["slice2"]))
+	myModel4.AssertEqual(t, modelStruct.ModelSliceMap["slice2"][0])
 
-	assert.Equal(t, "string1", *(modelStruct.ModelSliceMap["slice1"][0].Foo))
-	assert.Equal(t, int64(44), *(modelStruct.ModelSliceMap["slice1"][0].Bar))
-	assert.Equal(t, "string2", *(modelStruct.ModelSliceMap["slice1"][1].Foo))
-	assert.Equal(t, int64(74), *(modelStruct.ModelSliceMap["slice1"][1].Bar))
-	assert.Equal(t, "string3", *(modelStruct.ModelSliceMap["slice1"][2].Foo))
-	assert.Equal(t, int64(33), *(modelStruct.ModelSliceMap["slice1"][2].Bar))
+	// Verify slice of model slices (two-dimensional array of model instances).
+	assert.Equal(t, 3, len(modelStruct.ModelSliceSlice))
 
-	assert.Equal(t, "string4", *(modelStruct.ModelSliceMap["slice2"][0].Foo))
-	assert.Equal(t, int64(21), *(modelStruct.ModelSliceMap["slice2"][0].Bar))
+	assert.Equal(t, 2, len(modelStruct.ModelSliceSlice[0]))
+	myModel1.AssertEqual(t, modelStruct.ModelSliceSlice[0][0])
+	myModel2.AssertEqual(t, modelStruct.ModelSliceSlice[0][1])
+
+	assert.Equal(t, 1, len(modelStruct.ModelSliceSlice[1]))
+	myModel3.AssertEqual(t, modelStruct.ModelSliceSlice[1][0])
+
+	assert.Equal(t, 2, len(modelStruct.ModelSliceSlice[2]))
+	myModel4.AssertEqual(t, modelStruct.ModelSliceSlice[2][0])
+	myModel1.AssertEqual(t, modelStruct.ModelSliceSlice[2][1])
 }
 
 func TestUnmarshalModelAbstractInstance(t *testing.T) {
-	jsonString := `{ "vehicle_type": "Car", "make": "Ford", "body_style": "coupe"}`
-
 	var err error
 	var myVehicle VehicleIntf
 
-	// Unmarshal an instance of the parent (should end up with a Car).
+	jsonString := toJSON(car1)
 	rawMap := unmarshalMap(jsonString)
+
+	// Unmarshal an instance of the parent (should end up with a Car).
 	err = UnmarshalModel(rawMap, "", &myVehicle, UnmarshalVehicle)
 	assert.Nil(t, err)
 	assert.NotNil(t, myVehicle)
+
 	myCar, ok := myVehicle.(*Car)
 	assert.True(t, ok)
 	assert.NotNil(t, myCar)
-	assert.Equal(t, "Car", *(myCar.VehicleType))
-	assert.Equal(t, "Ford", *(myCar.Make))
-	assert.Equal(t, "coupe", *(myCar.BodyStyle))
+	car1.AssertEqual(t, *myCar)
 
 	// Unmarshal an instance of the substruct directly.
 	myCar = nil
 	err = UnmarshalModel(rawMap, "", &myCar, UnmarshalCar)
 	assert.Nil(t, err)
 	assert.NotNil(t, myCar)
-	assert.Equal(t, "Car", *(myCar.VehicleType))
-	assert.Equal(t, "Ford", *(myCar.Make))
-	assert.Equal(t, "coupe", *(myCar.BodyStyle))
+	car1.AssertEqual(t, *myCar)
 }
 
 func TestUnmarshalModelAbstractSlice(t *testing.T) {
-	jsonString := `[{ "vehicle_type": "Car", "make": "Ford", "body_style": "coupe"}]`
-
 	var err error
-	var myVehicleSlice []VehicleIntf
+
+	jsonTemplate := `[ %c1 ]`
+	jsonString := strings.ReplaceAll(jsonTemplate, "%c1", toJSON(car1))
+	rawSlice := unmarshalSlice(jsonString)
 
 	// Unmarshal a slice of Vehicles.
-	rawSlice := unmarshalSlice(jsonString)
+	var myVehicleSlice []VehicleIntf
 	err = UnmarshalModel(rawSlice, "", &myVehicleSlice, UnmarshalVehicle)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(myVehicleSlice))
 	myCar, ok := myVehicleSlice[0].(*Car)
 	assert.True(t, ok)
 	assert.NotNil(t, myCar)
-	assert.Equal(t, "Car", *(myCar.VehicleType))
-	assert.Equal(t, "Ford", *(myCar.Make))
-	assert.Equal(t, "coupe", *(myCar.BodyStyle))
+	car1.AssertEqual(t, *myCar)
 
 	// Unmarshal a slice of Cars directly.
 	var myCarSlice []Car
 	err = UnmarshalModel(rawSlice, "", &myCarSlice, UnmarshalCar)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(myCarSlice))
-	assert.Equal(t, "Car", *(myCarSlice[0].VehicleType))
-	assert.Equal(t, "Ford", *(myCarSlice[0].Make))
-	assert.Equal(t, "coupe", *(myCarSlice[0].BodyStyle))
-
+	car1.AssertEqual(t, myCarSlice[0])
 }
 
 func TestUnmarshalModelAbstractMap(t *testing.T) {
-	jsonString := `{ "car1": { "vehicle_type": "Car", "make": "Ford", "body_style": "coupe"} }`
-
 	var err error
-	var myVehicleMap map[string]VehicleIntf
 
+	jsonTemplate := `{ "car1": %c1 }`
+	jsonString := strings.ReplaceAll(jsonTemplate, "%c1", toJSON(car1))
 	rawMap := unmarshalMap(jsonString)
+
+	var myVehicleMap map[string]VehicleIntf
 	err = UnmarshalModel(rawMap, "", &myVehicleMap, UnmarshalVehicle)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(myVehicleMap))
 	myCar, ok := myVehicleMap["car1"].(*Car)
 	assert.True(t, ok)
 	assert.NotNil(t, myCar)
-	assert.Equal(t, "Car", *(myCar.VehicleType))
-	assert.Equal(t, "Ford", *(myCar.Make))
-	assert.Equal(t, "coupe", *(myCar.BodyStyle))
+	car1.AssertEqual(t, *myCar)
 
 	var myCarMap map[string]Car
 	err = UnmarshalModel(rawMap, "", &myCarMap, UnmarshalCar)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(myCarMap))
-	assert.Equal(t, "Car", *(myCarMap["car1"].VehicleType))
-	assert.Equal(t, "Ford", *(myCarMap["car1"].Make))
-	assert.Equal(t, "coupe", *(myCarMap["car1"].BodyStyle))
+	_, foundIt := myCarMap["car1"]
+	assert.True(t, foundIt)
+	car1.AssertEqual(t, myCarMap["car1"])
 }
 
 func TestUnmarshalModelAbstractSliceMap(t *testing.T) {
-	jsonString := `{ "carSlice1": [ { "vehicle_type": "Car", "make": "Ford", "body_style": "coupe"} ] }`
-
 	var err error
-	var myVehicleSliceMap map[string][]VehicleIntf
 
+	jsonTemplate := `{ "carSlice1": [ %c1 ] }`
+	jsonString := strings.ReplaceAll(jsonTemplate, "%c1", toJSON(car1))
 	rawMap := unmarshalMap(jsonString)
+
+	var myVehicleSliceMap map[string][]VehicleIntf
 	err = UnmarshalModel(rawMap, "", &myVehicleSliceMap, UnmarshalVehicle)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(myVehicleSliceMap))
 	myCar, ok := myVehicleSliceMap["carSlice1"][0].(*Car)
 	assert.True(t, ok)
 	assert.NotNil(t, myCar)
-	assert.Equal(t, "Car", *(myCar.VehicleType))
-	assert.Equal(t, "Ford", *(myCar.Make))
-	assert.Equal(t, "coupe", *(myCar.BodyStyle))
+	car1.AssertEqual(t, *myCar)
 
 	var myCarSliceMap map[string][]Car
 	err = UnmarshalModel(rawMap, "", &myCarSliceMap, UnmarshalVehicle)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(myCarSliceMap))
 	assert.Equal(t, 1, len(myCarSliceMap["carSlice1"]))
-	assert.Equal(t, "Car", *(myCarSliceMap["carSlice1"][0].VehicleType))
-	assert.Equal(t, "Ford", *(myCarSliceMap["carSlice1"][0].Make))
-	assert.Equal(t, "coupe", *(myCarSliceMap["carSlice1"][0].BodyStyle))
+	car1.AssertEqual(t, myCarSliceMap["carSlice1"][0])
 }
 
 func TestUnmarshalModelErrors(t *testing.T) {
@@ -627,6 +792,20 @@ func TestUnmarshalModelErrors(t *testing.T) {
 	assert.Nil(t, modelStruct.ModelSliceMap)
 	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'prop' as map[string][]core.MyModel"))
 	t.Logf("[12] Expected error: %s\n", err.Error())
+
+	// Supply a model slice when a slice of model slices is expected.
+	rawSlice = unmarshalSlice(`[ {"foo": "string", "bar": 44} ]`)
+	err = UnmarshalModel(rawSlice, "", &modelStruct.ModelSliceSlice, UnmarshalMyModel)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling [][]core.MyModel"))
+	t.Logf("[13] Expected error: %s\n", err.Error())
+
+	// Supply a map of model slices when a map containing a slice of model slices is expected.
+	rawMap = unmarshalMap(`{ "prop": [ {"foo": "string", "bar": 44} ] }`)
+	err = UnmarshalModel(rawMap, "prop", &modelStruct.ModelSliceSlice, UnmarshalMyModel)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'prop' as [][]core.MyModel"))
+	t.Logf("[14] Expected error: %s\n", err.Error())
 }
 
 func TestUnmarshalModelAbstractErrors(t *testing.T) {
@@ -635,6 +814,7 @@ func TestUnmarshalModelAbstractErrors(t *testing.T) {
 	var mySlice []VehicleIntf
 	var myMap map[string]VehicleIntf
 	var mySliceMap map[string][]VehicleIntf
+	var mySliceSlice [][]VehicleIntf
 	var rawMap map[string]json.RawMessage
 	var rawSlice []json.RawMessage
 
@@ -686,6 +866,20 @@ func TestUnmarshalModelAbstractErrors(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, 0, len(myMap))
 	t.Logf("[07] Expected error: %s\n", err.Error())
+
+	// Supply a model slice when a slice of model slices is expected.
+	rawSlice = unmarshalSlice(`[ { "vehicle_type": "EV", "make": "Ford", "body_style": 44 } ]`)
+	err = UnmarshalModel(rawSlice, "", &mySliceSlice, UnmarshalVehicle)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling [][]core.VehicleIntf"))
+	t.Logf("[08] Expected error: %s\n", err.Error())
+
+	// Supply a map of model slices when a map containing a slice of model slices is expected.
+	rawMap = unmarshalMap(`{ "prop": [ { "vehicle_type": "EV", "make": "Ford", "body_style": 44 } ] }`)
+	err = UnmarshalModel(rawMap, "prop", &mySliceSlice, UnmarshalVehicle)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "error unmarshalling property 'prop' as [][]core.VehicleIntf"))
+	t.Logf("[09] Expected error: %s\n", err.Error())
 }
 
 // Utility function that unmarshals a JSON string into

--- a/v5/core/unmarshal_v2_primitives_test.go
+++ b/v5/core/unmarshal_v2_primitives_test.go
@@ -33,6 +33,7 @@ func TestUnmarshalPrimitiveString(t *testing.T) {
 	type MyModel struct {
 		Prop              *string
 		PropSlice         []string
+		PropSliceSlice    [][]string
 		PropMap           map[string]string
 		PropSliceMap      map[string][]string
 		PropMapSlice      []map[string]string
@@ -42,6 +43,7 @@ func TestUnmarshalPrimitiveString(t *testing.T) {
 	jsonTemplate := `{
 		"prop": "%s1",
 		"prop_slice": ["%s1", "%s2"],
+		"prop_slice_slice": [["%s1"], ["%s2", "%s3"], ["%s4"]],
 		"prop_map": { "key1": "%s1", "key2": "%s2" },
 		"prop_slice_map": { "key1": ["%s1", "%s2"], "key2": ["%s3", "%s4"] },
 		"prop_map_slice": [{"key1": "%s1"}, {"key2": "%s2"}],
@@ -51,7 +53,8 @@ func TestUnmarshalPrimitiveString(t *testing.T) {
 		"not_a_slice": false,
 		"bad_slice_type": [38, 26],
 		"null_prop": null,
-		"slice_with_null": [ null, "%s1", null ]
+		"slice_with_null": [ null, "%s1", null ],
+		"slice_slice_with_null": [ null, [null], ["%s1"], ["%s1", null] ]
 	}`
 
 	s1 := "value1"
@@ -88,6 +91,20 @@ func TestUnmarshalPrimitiveString(t *testing.T) {
 	assert.NotNil(t, model.PropSlice)
 	assert.Equal(t, s1, model.PropSlice[0])
 	assert.Equal(t, s2, model.PropSlice[1])
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_slice", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+
+	assert.Equal(t, 3, len(model.PropSliceSlice))
+	assert.Equal(t, 1, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+
+	assert.Equal(t, s1, model.PropSliceSlice[0][0])
+	assert.Equal(t, s2, model.PropSliceSlice[1][0])
+	assert.Equal(t, s3, model.PropSliceSlice[1][1])
+	assert.Equal(t, s4, model.PropSliceSlice[2][0])
 
 	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
 	assert.Nil(t, err)
@@ -151,6 +168,22 @@ func TestUnmarshalPrimitiveString(t *testing.T) {
 	assert.Equal(t, s1, model.PropSlice[1])
 	assert.Equal(t, zeroValue, model.PropSlice[2])
 
+	model.PropSliceSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_slice_with_null", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+	assert.Equal(t, 4, len(model.PropSliceSlice))
+	assert.Equal(t, 0, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[3]))
+
+	assert.Nil(t, model.PropSliceSlice[0])
+	assert.Equal(t, zeroValue, model.PropSliceSlice[1][0])
+	assert.Equal(t, s1, model.PropSliceSlice[2][0])
+	assert.Equal(t, s1, model.PropSliceSlice[3][0])
+	assert.Equal(t, zeroValue, model.PropSliceSlice[3][1])
+
 	// Negative tests
 	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
 	assert.NotNil(t, err)
@@ -177,6 +210,7 @@ func TestUnmarshalPrimitiveBool(t *testing.T) {
 	type MyModel struct {
 		Prop              *bool
 		PropSlice         []bool
+		PropSliceSlice    [][]bool
 		PropMap           map[string]bool
 		PropSliceMap      map[string][]bool
 		PropMapSlice      []map[string]bool
@@ -186,6 +220,7 @@ func TestUnmarshalPrimitiveBool(t *testing.T) {
 	jsonTemplate := `{
 		"prop": %b1,
 		"prop_slice": [%b1, %b2],
+		"prop_slice_slice": [[%b1], [%b2, %b1], [%b2]],
 		"prop_map": { "key1": %b1, "key2": %b2 },
 		"prop_slice_map": { "key1": [%b2, %b1], "key2": [%b1, %b2] },
 		"prop_map_slice": [{"key1": %b1}, {"key2": %b2}],
@@ -195,7 +230,8 @@ func TestUnmarshalPrimitiveBool(t *testing.T) {
 		"not_a_slice": 38,
 		"bad_slice_type": [38, 26],
 		"null_prop": null,
-		"slice_with_null": [ null, %b1, null ]
+		"slice_with_null": [ null, %b1, null ],
+		"slice_slice_with_null": [ null, [null], [%b1], [%b1, null] ]
 	}`
 
 	b1 := true
@@ -228,6 +264,20 @@ func TestUnmarshalPrimitiveBool(t *testing.T) {
 	assert.NotNil(t, model.PropSlice)
 	assert.Equal(t, b1, model.PropSlice[0])
 	assert.Equal(t, b2, model.PropSlice[1])
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_slice", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+
+	assert.Equal(t, 3, len(model.PropSliceSlice))
+	assert.Equal(t, 1, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+
+	assert.Equal(t, b1, model.PropSliceSlice[0][0])
+	assert.Equal(t, b2, model.PropSliceSlice[1][0])
+	assert.Equal(t, b1, model.PropSliceSlice[1][1])
+	assert.Equal(t, b2, model.PropSliceSlice[2][0])
 
 	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
 	assert.Nil(t, err)
@@ -291,6 +341,22 @@ func TestUnmarshalPrimitiveBool(t *testing.T) {
 	assert.Equal(t, b1, model.PropSlice[1])
 	assert.Equal(t, zeroValue, model.PropSlice[2])
 
+	model.PropSliceSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_slice_with_null", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+	assert.Equal(t, 4, len(model.PropSliceSlice))
+	assert.Equal(t, 0, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[3]))
+
+	assert.Nil(t, model.PropSliceSlice[0])
+	assert.Equal(t, zeroValue, model.PropSliceSlice[1][0])
+	assert.Equal(t, b1, model.PropSliceSlice[2][0])
+	assert.Equal(t, b1, model.PropSliceSlice[3][0])
+	assert.Equal(t, zeroValue, model.PropSliceSlice[3][1])
+
 	// Negative tests
 	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
 	assert.NotNil(t, err)
@@ -312,6 +378,7 @@ func TestUnmarshalPrimitiveByteArray(t *testing.T) {
 	type MyModel struct {
 		Prop              *[]byte
 		PropSlice         [][]byte
+		PropSliceSlice    [][][]byte
 		PropMap           map[string][]byte
 		PropSliceMap      map[string][][]byte
 		PropMapSlice      []map[string][]byte
@@ -329,6 +396,7 @@ func TestUnmarshalPrimitiveByteArray(t *testing.T) {
 	jsonStringTemplate := `{
 		"prop": "%s1",
 		"prop_slice": ["%s1", "%s2"],
+		"prop_slice_slice": [["%s1"], ["%s2", "%s1"], ["%s2"]],
 		"prop_map": { "key1": "%s2", "key2": "%s1" },
 		"prop_slice_map": { "key1": ["%s1", "%s2"], "key2": ["%s2", "%s1"] },
 		"prop_map_slice": [{"key1": "%s2"}, {"key2": "%s1"}],
@@ -338,7 +406,8 @@ func TestUnmarshalPrimitiveByteArray(t *testing.T) {
 		"not_a_slice": false,
 		"bad_slice_type": [38, 26],
 		"null_prop": null,
-		"slice_with_null": [ null, "%s1", null ]
+		"slice_with_null": [ null, "%s1", null ],
+		"slice_slice_with_null": [ null, [null], ["%s1"], ["%s1", null] ]
 	}`
 
 	jsonString := strings.ReplaceAll(jsonStringTemplate, "%s1", encodedString1)
@@ -369,6 +438,20 @@ func TestUnmarshalPrimitiveByteArray(t *testing.T) {
 	assert.NotNil(t, model.PropSlice)
 	assert.Equal(t, s1, string(model.PropSlice[0]))
 	assert.Equal(t, s2, string(model.PropSlice[1]))
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_slice", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+
+	assert.Equal(t, 3, len(model.PropSliceSlice))
+	assert.Equal(t, 1, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+
+	assert.Equal(t, s1, string(model.PropSliceSlice[0][0]))
+	assert.Equal(t, s2, string(model.PropSliceSlice[1][0]))
+	assert.Equal(t, s1, string(model.PropSliceSlice[1][1]))
+	assert.Equal(t, s2, string(model.PropSliceSlice[2][0]))
 
 	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
 	assert.Nil(t, err)
@@ -432,6 +515,22 @@ func TestUnmarshalPrimitiveByteArray(t *testing.T) {
 	assert.Equal(t, s1, string(model.PropSlice[1]))
 	assert.Equal(t, zeroValue, model.PropSlice[2])
 
+	model.PropSliceSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_slice_with_null", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+	assert.Equal(t, 4, len(model.PropSliceSlice))
+	assert.Equal(t, 0, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[3]))
+
+	assert.Nil(t, model.PropSliceSlice[0])
+	assert.Equal(t, zeroValue, model.PropSliceSlice[1][0])
+	assert.Equal(t, s1, string(model.PropSliceSlice[2][0]))
+	assert.Equal(t, s1, string(model.PropSliceSlice[3][0]))
+	assert.Equal(t, zeroValue, model.PropSliceSlice[3][1])
+
 	// Negative tests
 	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
 	assert.NotNil(t, err)
@@ -453,6 +552,7 @@ func TestUnmarshalPrimitiveInt64(t *testing.T) {
 	type MyModel struct {
 		Prop              *int64
 		PropSlice         []int64
+		PropSliceSlice    [][]int64
 		PropMap           map[string]int64
 		PropSliceMap      map[string][]int64
 		PropMapSlice      []map[string]int64
@@ -462,6 +562,7 @@ func TestUnmarshalPrimitiveInt64(t *testing.T) {
 	jsonTemplate := `{
 		"prop": %n1,
 		"prop_slice": [%n1, %n2],
+		"prop_slice_slice": [[%n1], [%n2, %n3], [%n4]],
 		"prop_map": { "key1": %n1, "key2": %n2 },
 		"prop_slice_map": { "key1": [%n1, %n2], "key2": [%n3, %n4] },
 		"prop_map_slice": [{"key1": %n1}, {"key2": %n2}],
@@ -471,7 +572,8 @@ func TestUnmarshalPrimitiveInt64(t *testing.T) {
 		"not_a_slice": false,
 		"bad_slice_type": [true, false],
 		"null_prop": null,
-		"slice_with_null": [ null, %n1, null ]
+		"slice_with_null": [ null, %n1, null ],
+		"slice_slice_with_null": [ null, [null], [%n1], [%n1, null] ]
 	}`
 
 	n1 := int64(44)
@@ -509,6 +611,20 @@ func TestUnmarshalPrimitiveInt64(t *testing.T) {
 	assert.Equal(t, n1, model.PropSlice[0])
 	assert.Equal(t, n2, model.PropSlice[1])
 
+	err = UnmarshalPrimitive(rawMap, "prop_slice_slice", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+
+	assert.Equal(t, 3, len(model.PropSliceSlice))
+	assert.Equal(t, 1, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+
+	assert.Equal(t, n1, model.PropSliceSlice[0][0])
+	assert.Equal(t, n2, model.PropSliceSlice[1][0])
+	assert.Equal(t, n3, model.PropSliceSlice[1][1])
+	assert.Equal(t, n4, model.PropSliceSlice[2][0])
+
 	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
 	assert.Nil(t, err)
 	assert.NotNil(t, model.PropMap)
@@ -571,6 +687,22 @@ func TestUnmarshalPrimitiveInt64(t *testing.T) {
 	assert.Equal(t, n1, model.PropSlice[1])
 	assert.Equal(t, zeroValue, model.PropSlice[2])
 
+	model.PropSliceSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_slice_with_null", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+	assert.Equal(t, 4, len(model.PropSliceSlice))
+	assert.Equal(t, 0, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[3]))
+
+	assert.Nil(t, model.PropSliceSlice[0])
+	assert.Equal(t, zeroValue, model.PropSliceSlice[1][0])
+	assert.Equal(t, n1, model.PropSliceSlice[2][0])
+	assert.Equal(t, n1, model.PropSliceSlice[3][0])
+	assert.Equal(t, zeroValue, model.PropSliceSlice[3][1])
+
 	// Negative tests
 	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
 	assert.NotNil(t, err)
@@ -592,6 +724,7 @@ func TestUnmarshalPrimitiveFloat32(t *testing.T) {
 	type MyModel struct {
 		Prop              *float32
 		PropSlice         []float32
+		PropSliceSlice    [][]float32
 		PropMap           map[string]float32
 		PropSliceMap      map[string][]float32
 		PropMapSlice      []map[string]float32
@@ -601,6 +734,7 @@ func TestUnmarshalPrimitiveFloat32(t *testing.T) {
 	jsonTemplate := `{
 		"prop": %n1,
 		"prop_slice": [%n1, %n2],
+		"prop_slice_slice": [[%n1], [%n2, %n3], [%n4]],
 		"prop_map": { "key1": %n1, "key2": %n2 },
 		"prop_slice_map": { "key1": [%n1, %n2], "key2": [%n3, %n4] },
 		"prop_map_slice": [{"key1": %n1}, {"key2": %n2}],
@@ -610,7 +744,8 @@ func TestUnmarshalPrimitiveFloat32(t *testing.T) {
 		"not_a_slice": false,
 		"bad_slice_type": [true, false],
 		"null_prop": null,
-		"slice_with_null": [ null, %n1, null ]
+		"slice_with_null": [ null, %n1, null ],
+		"slice_slice_with_null": [ null, [null], [%n1], [%n1, null] ]
 	}`
 
 	n1 := float32(44.5)
@@ -648,6 +783,20 @@ func TestUnmarshalPrimitiveFloat32(t *testing.T) {
 	assert.Equal(t, n1, model.PropSlice[0])
 	assert.Equal(t, n2, model.PropSlice[1])
 
+	err = UnmarshalPrimitive(rawMap, "prop_slice_slice", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+
+	assert.Equal(t, 3, len(model.PropSliceSlice))
+	assert.Equal(t, 1, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+
+	assert.Equal(t, n1, model.PropSliceSlice[0][0])
+	assert.Equal(t, n2, model.PropSliceSlice[1][0])
+	assert.Equal(t, n3, model.PropSliceSlice[1][1])
+	assert.Equal(t, n4, model.PropSliceSlice[2][0])
+
 	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
 	assert.Nil(t, err)
 	assert.NotNil(t, model.PropMap)
@@ -710,6 +859,22 @@ func TestUnmarshalPrimitiveFloat32(t *testing.T) {
 	assert.Equal(t, n1, model.PropSlice[1])
 	assert.Equal(t, zeroValue, model.PropSlice[2])
 
+	model.PropSliceSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_slice_with_null", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+	assert.Equal(t, 4, len(model.PropSliceSlice))
+	assert.Equal(t, 0, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[3]))
+
+	assert.Nil(t, model.PropSliceSlice[0])
+	assert.Equal(t, zeroValue, model.PropSliceSlice[1][0])
+	assert.Equal(t, n1, model.PropSliceSlice[2][0])
+	assert.Equal(t, n1, model.PropSliceSlice[3][0])
+	assert.Equal(t, zeroValue, model.PropSliceSlice[3][1])
+
 	// Negative tests
 	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
 	assert.NotNil(t, err)
@@ -731,6 +896,7 @@ func TestUnmarshalPrimitiveFloat64(t *testing.T) {
 	type MyModel struct {
 		Prop              *float64
 		PropSlice         []float64
+		PropSliceSlice    [][]float64
 		PropMap           map[string]float64
 		PropSliceMap      map[string][]float64
 		PropMapSlice      []map[string]float64
@@ -740,6 +906,7 @@ func TestUnmarshalPrimitiveFloat64(t *testing.T) {
 	jsonTemplate := `{
 		"prop": %n1,
 		"prop_slice": [%n1, %n2],
+		"prop_slice_slice": [[%n1], [%n2, %n3], [%n4]],
 		"prop_map": { "key1": %n1, "key2": %n2 },
 		"prop_slice_map": { "key1": [%n1, %n2], "key2": [%n3, %n4] },
 		"prop_map_slice": [{"key1": %n1}, {"key2": %n2}],
@@ -749,7 +916,8 @@ func TestUnmarshalPrimitiveFloat64(t *testing.T) {
 		"not_a_slice": false,
 		"bad_slice_type": [true, false],
 		"null_prop": null,
-		"slice_with_null": [ null, %n1, null ]
+		"slice_with_null": [ null, %n1, null ],
+		"slice_slice_with_null": [ null, [null], [%n1], [%n1, null] ]
 	}`
 
 	n1 := float64(44.5)
@@ -787,6 +955,20 @@ func TestUnmarshalPrimitiveFloat64(t *testing.T) {
 	assert.Equal(t, n1, model.PropSlice[0])
 	assert.Equal(t, n2, model.PropSlice[1])
 
+	err = UnmarshalPrimitive(rawMap, "prop_slice_slice", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+
+	assert.Equal(t, 3, len(model.PropSliceSlice))
+	assert.Equal(t, 1, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+
+	assert.Equal(t, n1, model.PropSliceSlice[0][0])
+	assert.Equal(t, n2, model.PropSliceSlice[1][0])
+	assert.Equal(t, n3, model.PropSliceSlice[1][1])
+	assert.Equal(t, n4, model.PropSliceSlice[2][0])
+
 	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
 	assert.Nil(t, err)
 	assert.NotNil(t, model.PropMap)
@@ -849,6 +1031,22 @@ func TestUnmarshalPrimitiveFloat64(t *testing.T) {
 	assert.Equal(t, n1, model.PropSlice[1])
 	assert.Equal(t, zeroValue, model.PropSlice[2])
 
+	model.PropSliceSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_slice_with_null", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+	assert.Equal(t, 4, len(model.PropSliceSlice))
+	assert.Equal(t, 0, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[3]))
+
+	assert.Nil(t, model.PropSliceSlice[0])
+	assert.Equal(t, zeroValue, model.PropSliceSlice[1][0])
+	assert.Equal(t, n1, model.PropSliceSlice[2][0])
+	assert.Equal(t, n1, model.PropSliceSlice[3][0])
+	assert.Equal(t, zeroValue, model.PropSliceSlice[3][1])
+
 	// Negative tests
 	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
 	assert.NotNil(t, err)
@@ -870,6 +1068,7 @@ func TestUnmarshalPrimitiveDate(t *testing.T) {
 	type MyModel struct {
 		Prop              *strfmt.Date
 		PropSlice         []strfmt.Date
+		PropSliceSlice    [][]strfmt.Date
 		PropMap           map[string]strfmt.Date
 		PropSliceMap      map[string][]strfmt.Date
 		PropMapSlice      []map[string]strfmt.Date
@@ -879,6 +1078,7 @@ func TestUnmarshalPrimitiveDate(t *testing.T) {
 	jsonTemplate := `{
 		"prop": "%d1",
 		"prop_slice": ["%d1", "%d2"],
+		"prop_slice_slice": [["%d1"], ["%d2", "%d3"], ["%d4" ]],
 		"prop_map": { "key1": "%d1", "key2": "%d2" },
 		"prop_slice_map": { "key1": ["%d1", "%d2"], "key2": ["%d3", "%d4"] },
 		"prop_map_slice": [{"key1": "%d1"}, {"key2": "%d2"}],
@@ -891,7 +1091,8 @@ func TestUnmarshalPrimitiveDate(t *testing.T) {
 		"not_a_slice": false,
 		"bad_slice_type": [38, 26],
 		"null_prop": null,
-		"slice_with_null": [ null, "%d1", null ]
+		"slice_with_null": [ null, "%d1", null ],
+		"slice_slice_with_null": [ null, [null], ["%d1"], ["%d1", null] ]
 	}`
 
 	d1 := "2004-10-27"
@@ -928,6 +1129,20 @@ func TestUnmarshalPrimitiveDate(t *testing.T) {
 	assert.NotNil(t, model.PropSlice)
 	assert.Equal(t, d1, model.PropSlice[0].String())
 	assert.Equal(t, d2, model.PropSlice[1].String())
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_slice", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+
+	assert.Equal(t, 3, len(model.PropSliceSlice))
+	assert.Equal(t, 1, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+
+	assert.Equal(t, d1, model.PropSliceSlice[0][0].String())
+	assert.Equal(t, d2, model.PropSliceSlice[1][0].String())
+	assert.Equal(t, d3, model.PropSliceSlice[1][1].String())
+	assert.Equal(t, d4, model.PropSliceSlice[2][0].String())
 
 	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
 	assert.Nil(t, err)
@@ -991,6 +1206,22 @@ func TestUnmarshalPrimitiveDate(t *testing.T) {
 	assert.Equal(t, d1, model.PropSlice[1].String())
 	assert.Equal(t, zeroValue.String(), model.PropSlice[2].String())
 
+	model.PropSliceSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_slice_with_null", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+	assert.Equal(t, 4, len(model.PropSliceSlice))
+	assert.Equal(t, 0, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[3]))
+
+	assert.Nil(t, model.PropSliceSlice[0])
+	assert.Equal(t, zeroValue.String(), model.PropSliceSlice[1][0].String())
+	assert.Equal(t, d1, model.PropSliceSlice[2][0].String())
+	assert.Equal(t, d1, model.PropSliceSlice[3][0].String())
+	assert.Equal(t, zeroValue.String(), model.PropSliceSlice[3][1].String())
+
 	// Negative tests
 	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
 	assert.NotNil(t, err)
@@ -1027,6 +1258,7 @@ func TestUnmarshalPrimitiveDateTime(t *testing.T) {
 	type MyModel struct {
 		Prop              *strfmt.DateTime
 		PropSlice         []strfmt.DateTime
+		PropSliceSlice    [][]strfmt.DateTime
 		PropMap           map[string]strfmt.DateTime
 		PropSliceMap      map[string][]strfmt.DateTime
 		PropMapSlice      []map[string]strfmt.DateTime
@@ -1036,6 +1268,7 @@ func TestUnmarshalPrimitiveDateTime(t *testing.T) {
 	jsonTemplate := `{
 		"prop": "%d1",
 		"prop_slice": ["%d1", "%d2"],
+		"prop_slice_slice": [["%d1"], ["%d2", "%d3"], ["%d4" ]],
 		"prop_map": { "key1": "%d1", "key2": "%d2" },
 		"prop_slice_map": { "key1": ["%d1", "%d2"], "key2": ["%d3", "%d4"] },
 		"prop_map_slice": [{"key1": "%d1"}, {"key2": "%d2"}],
@@ -1048,7 +1281,8 @@ func TestUnmarshalPrimitiveDateTime(t *testing.T) {
 		"not_a_slice": false,
 		"bad_slice_type": [38, 26],
 		"null_prop": null,
-		"slice_with_null": [ null, "%d1", null ]
+		"slice_with_null": [ null, "%d1", null ],
+		"slice_slice_with_null": [ null, [null], ["%d1"], ["%d1", null] ]
 	}`
 
 	d1 := "1969-07-20T20:17:00"
@@ -1090,6 +1324,20 @@ func TestUnmarshalPrimitiveDateTime(t *testing.T) {
 	assert.Equal(t, d1, model.PropSlice[0].String())
 	assert.Equal(t, d2, model.PropSlice[1].String())
 
+	err = UnmarshalPrimitive(rawMap, "prop_slice_slice", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+
+	assert.Equal(t, 3, len(model.PropSliceSlice))
+	assert.Equal(t, 1, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+
+	assert.Equal(t, d1, model.PropSliceSlice[0][0].String())
+	assert.Equal(t, d2, model.PropSliceSlice[1][0].String())
+	assert.Equal(t, d3, model.PropSliceSlice[1][1].String())
+	assert.Equal(t, d4, model.PropSliceSlice[2][0].String())
+
 	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
 	assert.Nil(t, err)
 	assert.NotNil(t, model.PropMap)
@@ -1152,6 +1400,22 @@ func TestUnmarshalPrimitiveDateTime(t *testing.T) {
 	assert.Equal(t, d1, model.PropSlice[1].String())
 	assert.Equal(t, zeroValue.String(), model.PropSlice[2].String())
 
+	model.PropSliceSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_slice_with_null", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+	assert.Equal(t, 4, len(model.PropSliceSlice))
+	assert.Equal(t, 0, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[3]))
+
+	assert.Nil(t, model.PropSliceSlice[0])
+	assert.Equal(t, zeroValue.String(), model.PropSliceSlice[1][0].String())
+	assert.Equal(t, d1, model.PropSliceSlice[2][0].String())
+	assert.Equal(t, d1, model.PropSliceSlice[3][0].String())
+	assert.Equal(t, zeroValue.String(), model.PropSliceSlice[3][1].String())
+
 	// Negative tests
 	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
 	assert.NotNil(t, err)
@@ -1190,6 +1454,7 @@ func TestUnmarshalPrimitiveUUID(t *testing.T) {
 	type MyModel struct {
 		Prop              *strfmt.UUID
 		PropSlice         []strfmt.UUID
+		PropSliceSlice    [][]strfmt.UUID
 		PropMap           map[string]strfmt.UUID
 		PropSliceMap      map[string][]strfmt.UUID
 		PropMapSlice      []map[string]strfmt.UUID
@@ -1199,6 +1464,7 @@ func TestUnmarshalPrimitiveUUID(t *testing.T) {
 	jsonTemplate := `{
 		"prop": "%u1",
 		"prop_slice": ["%u1", "%u2"],
+		"prop_slice_slice": [["%u1"], ["%u2", "%u3"], ["%u4" ]],
 		"prop_map": { "key1": "%u1", "key2": "%u2" },
 		"prop_slice_map": { "key1": ["%u1", "%u2"], "key2": ["%u3", "%u4"] },
 		"prop_map_slice": [{"key1": "%u1"}, {"key2": "%u2"}],
@@ -1210,7 +1476,8 @@ func TestUnmarshalPrimitiveUUID(t *testing.T) {
 		"not_a_slice": false,
 		"bad_slice_type": [38, 26],
 		"null_prop": null,
-		"slice_with_null": [ null, "%u1", null ]
+		"slice_with_null": [ null, "%u1", null ],
+		"slice_slice_with_null": [ null, [null], ["%u1"], ["%u1", null] ]
 	}`
 
 	u1 := "63769e9f-94e6-4ab6-8c68-dd33f69fb535"
@@ -1247,6 +1514,20 @@ func TestUnmarshalPrimitiveUUID(t *testing.T) {
 	assert.NotNil(t, model.PropSlice)
 	assert.Equal(t, u1, model.PropSlice[0].String())
 	assert.Equal(t, u2, model.PropSlice[1].String())
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_slice", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+
+	assert.Equal(t, 3, len(model.PropSliceSlice))
+	assert.Equal(t, 1, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+
+	assert.Equal(t, u1, model.PropSliceSlice[0][0].String())
+	assert.Equal(t, u2, model.PropSliceSlice[1][0].String())
+	assert.Equal(t, u3, model.PropSliceSlice[1][1].String())
+	assert.Equal(t, u4, model.PropSliceSlice[2][0].String())
 
 	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
 	assert.Nil(t, err)
@@ -1310,6 +1591,22 @@ func TestUnmarshalPrimitiveUUID(t *testing.T) {
 	assert.Equal(t, u1, model.PropSlice[1].String())
 	assert.Equal(t, zeroValue.String(), model.PropSlice[2].String())
 
+	model.PropSliceSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_slice_with_null", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+	assert.Equal(t, 4, len(model.PropSliceSlice))
+	assert.Equal(t, 0, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[3]))
+
+	assert.Nil(t, model.PropSliceSlice[0])
+	assert.Equal(t, zeroValue.String(), model.PropSliceSlice[1][0].String())
+	assert.Equal(t, u1, model.PropSliceSlice[2][0].String())
+	assert.Equal(t, u1, model.PropSliceSlice[3][0].String())
+	assert.Equal(t, zeroValue.String(), model.PropSliceSlice[3][1].String())
+
 	// Negative tests
 	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
 	assert.NotNil(t, err)
@@ -1339,6 +1636,7 @@ func TestUnmarshalPrimitiveAny(t *testing.T) {
 	type MyModel struct {
 		Prop              interface{}
 		PropSlice         []interface{}
+		PropSliceSlice    [][]interface{}
 		PropMap           map[string]interface{}
 		PropSliceMap      map[string][]interface{}
 		PropMapSlice      []map[string]interface{}
@@ -1348,6 +1646,7 @@ func TestUnmarshalPrimitiveAny(t *testing.T) {
 	jsonTemplate := `{
 		"prop": "%s1",
 		"prop_slice": [%n1, %n2],
+		"prop_slice_slice": [["%s1"], [%b1, %b2], [%n1]],
 		"prop_map": { "key1": %b1, "key2": %b2 },
 		"prop_slice_map": { "key1": [%n1, %n2], "key2": [%n2, %n1] },
 		"prop_map_slice": [{"key1": %f1}, {"key2": %f1}],
@@ -1357,7 +1656,8 @@ func TestUnmarshalPrimitiveAny(t *testing.T) {
 		"not_a_slice": false,
 		"ok_slice_type": [38, 26],
 		"null_prop": null,
-		"slice_with_null": [ null, "%s1", null ]
+		"slice_with_null": [ null, "%s1", null ],
+		"slice_slice_with_null": [ null, [null], ["%s1"], [%f1, null] ]
 	}`
 
 	s1 := "value1"
@@ -1393,6 +1693,20 @@ func TestUnmarshalPrimitiveAny(t *testing.T) {
 	assert.NotNil(t, model.PropSlice)
 	assert.Equal(t, n1, int64(model.PropSlice[0].(float64)))
 	assert.Equal(t, n2, int64(model.PropSlice[1].(float64)))
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_slice", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+
+	assert.Equal(t, 3, len(model.PropSliceSlice))
+	assert.Equal(t, 1, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+
+	assert.Equal(t, s1, model.PropSliceSlice[0][0].(string))
+	assert.Equal(t, b1, model.PropSliceSlice[1][0].(bool))
+	assert.Equal(t, b2, model.PropSliceSlice[1][1].(bool))
+	assert.Equal(t, n1, int64(model.PropSliceSlice[2][0].(float64)))
 
 	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
 	assert.Nil(t, err)
@@ -1459,6 +1773,22 @@ func TestUnmarshalPrimitiveAny(t *testing.T) {
 	assert.Equal(t, s1, model.PropSlice[1].(string))
 	assert.Equal(t, zeroValue, model.PropSlice[2])
 
+	model.PropSliceSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_slice_with_null", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+	assert.Equal(t, 4, len(model.PropSliceSlice))
+	assert.Equal(t, 0, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[3]))
+
+	assert.Nil(t, model.PropSliceSlice[0])
+	assert.Equal(t, zeroValue, model.PropSliceSlice[1][0])
+	assert.Equal(t, s1, model.PropSliceSlice[2][0].(string))
+	assert.Equal(t, f1, model.PropSliceSlice[3][0].(float64))
+	assert.Equal(t, zeroValue, model.PropSliceSlice[3][1])
+
 	// Negative tests
 	model.Prop = nil
 	err = UnmarshalPrimitive(rawMap, "ok_type", &model.Prop)
@@ -1480,6 +1810,7 @@ func TestUnmarshalPrimitiveAnyObject(t *testing.T) {
 	type MyModel struct {
 		Prop              map[string]interface{}
 		PropSlice         []map[string]interface{}
+		PropSliceSlice    [][]map[string]interface{}
 		PropMap           map[string]map[string]interface{}
 		PropSliceMap      map[string][]map[string]interface{}
 		PropMapSlice      []map[string]map[string]interface{}
@@ -1489,6 +1820,7 @@ func TestUnmarshalPrimitiveAnyObject(t *testing.T) {
 	jsonTemplate := `{
 		"prop": %o1,
 		"prop_slice": [%o1, %o2],
+		"prop_slice_slice": [[%o1], [%o2, %o1], [%o2]],
 		"prop_map": { "key1": %o1, "key2": %o2 },
 		"prop_slice_map": { "key1": [%o1, %o2], "key2": [%o2, %o1] },
 		"prop_map_slice": [{"key1": %o1}, {"key2": %o2}],
@@ -1498,7 +1830,8 @@ func TestUnmarshalPrimitiveAnyObject(t *testing.T) {
 		"not_a_slice": false,
 		"bad_slice_type": [38, 26],
 		"null_prop": null,
-		"slice_with_null": [ null, %o1, null ]
+		"slice_with_null": [ null, %o1, null ],
+		"slice_slice_with_null": [ null, [null], [%o1], [%o1, null] ]
 	}`
 
 	o1 := `{"field1": "value1"}`
@@ -1524,6 +1857,15 @@ func TestUnmarshalPrimitiveAnyObject(t *testing.T) {
 	err = UnmarshalPrimitive(rawMap, "prop_slice", &model.PropSlice)
 	assert.Nil(t, err)
 	assert.NotNil(t, model.PropSlice)
+
+	err = UnmarshalPrimitive(rawMap, "prop_slice_slice", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+
+	assert.Equal(t, 3, len(model.PropSliceSlice))
+	assert.Equal(t, 1, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
 
 	err = UnmarshalPrimitive(rawMap, "prop_map", &model.PropMap)
 	assert.Nil(t, err)
@@ -1577,6 +1919,22 @@ func TestUnmarshalPrimitiveAnyObject(t *testing.T) {
 	assert.Equal(t, zeroValue, model.PropSlice[0])
 	assert.Equal(t, o1AsAnyObject, model.PropSlice[1])
 	assert.Equal(t, zeroValue, model.PropSlice[2])
+
+	model.PropSliceSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_slice_with_null", &model.PropSliceSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSliceSlice)
+	assert.Equal(t, 4, len(model.PropSliceSlice))
+	assert.Equal(t, 0, len(model.PropSliceSlice[0]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[1]))
+	assert.Equal(t, 1, len(model.PropSliceSlice[2]))
+	assert.Equal(t, 2, len(model.PropSliceSlice[3]))
+
+	assert.Nil(t, model.PropSliceSlice[0])
+	assert.Equal(t, zeroValue, model.PropSliceSlice[1][0])
+	assert.Equal(t, o1AsAnyObject, model.PropSliceSlice[2][0])
+	assert.Equal(t, o1AsAnyObject, model.PropSliceSlice[3][0])
+	assert.Equal(t, zeroValue, model.PropSliceSlice[3][1])
 
 	// Negative tests
 	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)

--- a/v5/core/unmarshal_v2_primitives_test.go
+++ b/v5/core/unmarshal_v2_primitives_test.go
@@ -50,13 +50,15 @@ func TestUnmarshalPrimitiveString(t *testing.T) {
 		"bad_type":  true,
 		"not_a_slice": false,
 		"bad_slice_type": [38, 26],
-		"null_prop": null
+		"null_prop": null,
+		"slice_with_null": [ null, "%s1", null ]
 	}`
 
 	s1 := "value1"
 	s2 := "value2"
 	s3 := "value3"
 	s4 := "value4"
+	var zeroValue string
 
 	jsonString := strings.ReplaceAll(jsonTemplate, "%s1", s1)
 	jsonString = strings.ReplaceAll(jsonString, "%s2", s2)
@@ -140,6 +142,15 @@ func TestUnmarshalPrimitiveString(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, model.PropSliceMapSlice)
 
+	model.PropSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_with_null", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, 3, len(model.PropSlice))
+	assert.Equal(t, zeroValue, model.PropSlice[0])
+	assert.Equal(t, s1, model.PropSlice[1])
+	assert.Equal(t, zeroValue, model.PropSlice[2])
+
 	// Negative tests
 	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
 	assert.NotNil(t, err)
@@ -183,11 +194,13 @@ func TestUnmarshalPrimitiveBool(t *testing.T) {
 		"bad_type":  "string",
 		"not_a_slice": 38,
 		"bad_slice_type": [38, 26],
-		"null_prop": null
+		"null_prop": null,
+		"slice_with_null": [ null, %b1, null ]
 	}`
 
 	b1 := true
 	b2 := false
+	var zeroValue bool
 
 	jsonString := strings.ReplaceAll(jsonTemplate, "%b1", "true")
 	jsonString = strings.ReplaceAll(jsonString, "%b2", "false")
@@ -269,6 +282,15 @@ func TestUnmarshalPrimitiveBool(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, model.PropSliceMapSlice)
 
+	model.PropSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_with_null", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, 3, len(model.PropSlice))
+	assert.Equal(t, zeroValue, model.PropSlice[0])
+	assert.Equal(t, b1, model.PropSlice[1])
+	assert.Equal(t, zeroValue, model.PropSlice[2])
+
 	// Negative tests
 	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
 	assert.NotNil(t, err)
@@ -302,6 +324,7 @@ func TestUnmarshalPrimitiveByteArray(t *testing.T) {
 	encodedString2 := base64.StdEncoding.EncodeToString([]byte(s2))
 	assert.NotNil(t, encodedString1)
 	assert.NotNil(t, encodedString2)
+	var zeroValue []byte
 
 	jsonStringTemplate := `{
 		"prop": "%s1",
@@ -314,7 +337,8 @@ func TestUnmarshalPrimitiveByteArray(t *testing.T) {
 		"bad_type":  true,
 		"not_a_slice": false,
 		"bad_slice_type": [38, 26],
-		"null_prop": null
+		"null_prop": null,
+		"slice_with_null": [ null, "%s1", null ]
 	}`
 
 	jsonString := strings.ReplaceAll(jsonStringTemplate, "%s1", encodedString1)
@@ -399,6 +423,15 @@ func TestUnmarshalPrimitiveByteArray(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, model.PropSliceMapSlice)
 
+	model.PropSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_with_null", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, 3, len(model.PropSlice))
+	assert.Equal(t, zeroValue, model.PropSlice[0])
+	assert.Equal(t, s1, string(model.PropSlice[1]))
+	assert.Equal(t, zeroValue, model.PropSlice[2])
+
 	// Negative tests
 	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
 	assert.NotNil(t, err)
@@ -437,13 +470,15 @@ func TestUnmarshalPrimitiveInt64(t *testing.T) {
 		"bad_type":  true,
 		"not_a_slice": false,
 		"bad_slice_type": [true, false],
-		"null_prop": null
+		"null_prop": null,
+		"slice_with_null": [ null, %n1, null ]
 	}`
 
 	n1 := int64(44)
 	n2 := int64(74)
 	n3 := int64(27)
 	n4 := int64(50)
+	var zeroValue int64
 
 	jsonString := strings.ReplaceAll(jsonTemplate, "%n1", fmt.Sprintf("%d", n1))
 	jsonString = strings.ReplaceAll(jsonString, "%n2", fmt.Sprintf("%d", n2))
@@ -527,6 +562,15 @@ func TestUnmarshalPrimitiveInt64(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, model.PropSliceMapSlice)
 
+	model.PropSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_with_null", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, 3, len(model.PropSlice))
+	assert.Equal(t, zeroValue, model.PropSlice[0])
+	assert.Equal(t, n1, model.PropSlice[1])
+	assert.Equal(t, zeroValue, model.PropSlice[2])
+
 	// Negative tests
 	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
 	assert.NotNil(t, err)
@@ -565,13 +609,15 @@ func TestUnmarshalPrimitiveFloat32(t *testing.T) {
 		"bad_type":  true,
 		"not_a_slice": false,
 		"bad_slice_type": [true, false],
-		"null_prop": null
+		"null_prop": null,
+		"slice_with_null": [ null, %n1, null ]
 	}`
 
 	n1 := float32(44.5)
 	n2 := float32(74.8)
 	n3 := float32(27.1)
 	n4 := float32(50.9)
+	var zeroValue float32
 
 	jsonString := strings.ReplaceAll(jsonTemplate, "%n1", fmt.Sprintf("%f", n1))
 	jsonString = strings.ReplaceAll(jsonString, "%n2", fmt.Sprintf("%f", n2))
@@ -655,6 +701,15 @@ func TestUnmarshalPrimitiveFloat32(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, model.PropSliceMapSlice)
 
+	model.PropSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_with_null", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, 3, len(model.PropSlice))
+	assert.Equal(t, zeroValue, model.PropSlice[0])
+	assert.Equal(t, n1, model.PropSlice[1])
+	assert.Equal(t, zeroValue, model.PropSlice[2])
+
 	// Negative tests
 	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
 	assert.NotNil(t, err)
@@ -693,13 +748,15 @@ func TestUnmarshalPrimitiveFloat64(t *testing.T) {
 		"bad_type":  true,
 		"not_a_slice": false,
 		"bad_slice_type": [true, false],
-		"null_prop": null
+		"null_prop": null,
+		"slice_with_null": [ null, %n1, null ]
 	}`
 
 	n1 := float64(44.5)
 	n2 := float64(74.8)
 	n3 := float64(27.1)
 	n4 := float64(50.9)
+	var zeroValue float64
 
 	jsonString := strings.ReplaceAll(jsonTemplate, "%n1", fmt.Sprintf("%f", n1))
 	jsonString = strings.ReplaceAll(jsonString, "%n2", fmt.Sprintf("%f", n2))
@@ -783,6 +840,15 @@ func TestUnmarshalPrimitiveFloat64(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, model.PropSliceMapSlice)
 
+	model.PropSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_with_null", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, 3, len(model.PropSlice))
+	assert.Equal(t, zeroValue, model.PropSlice[0])
+	assert.Equal(t, n1, model.PropSlice[1])
+	assert.Equal(t, zeroValue, model.PropSlice[2])
+
 	// Negative tests
 	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
 	assert.NotNil(t, err)
@@ -824,13 +890,15 @@ func TestUnmarshalPrimitiveDate(t *testing.T) {
 		"bad_date3": "she/he was a psycho",
 		"not_a_slice": false,
 		"bad_slice_type": [38, 26],
-		"null_prop": null
+		"null_prop": null,
+		"slice_with_null": [ null, "%d1", null ]
 	}`
 
 	d1 := "2004-10-27"
 	d2 := "2007-10-28"
 	d3 := "2013-10-30"
 	d4 := "2018-10-28"
+	var zeroValue strfmt.Date
 
 	jsonString := strings.ReplaceAll(jsonTemplate, "%d1", d1)
 	jsonString = strings.ReplaceAll(jsonString, "%d2", d2)
@@ -914,6 +982,15 @@ func TestUnmarshalPrimitiveDate(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, model.PropSliceMapSlice)
 
+	model.PropSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_with_null", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, 3, len(model.PropSlice))
+	assert.Equal(t, zeroValue.String(), model.PropSlice[0].String())
+	assert.Equal(t, d1, model.PropSlice[1].String())
+	assert.Equal(t, zeroValue.String(), model.PropSlice[2].String())
+
 	// Negative tests
 	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
 	assert.NotNil(t, err)
@@ -970,13 +1047,15 @@ func TestUnmarshalPrimitiveDateTime(t *testing.T) {
 		"bad_date3": "1970-01-01 18:30:00Z",
 		"not_a_slice": false,
 		"bad_slice_type": [38, 26],
-		"null_prop": null
+		"null_prop": null,
+		"slice_with_null": [ null, "%d1", null ]
 	}`
 
 	d1 := "1969-07-20T20:17:00"
 	d2 := "1963-11-22T18:30:00Z"
 	d3 := "2001-09-11T13:46:00.333Z"
 	d4 := "2011-05-02T20:00:00.011Z"
+	var zeroValue strfmt.DateTime
 
 	jsonString := strings.ReplaceAll(jsonTemplate, "%d1", d1)
 	jsonString = strings.ReplaceAll(jsonString, "%d2", d2)
@@ -1064,6 +1143,15 @@ func TestUnmarshalPrimitiveDateTime(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, model.PropSliceMapSlice)
 
+	model.PropSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_with_null", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, 3, len(model.PropSlice))
+	assert.Equal(t, zeroValue.String(), model.PropSlice[0].String())
+	assert.Equal(t, d1, model.PropSlice[1].String())
+	assert.Equal(t, zeroValue.String(), model.PropSlice[2].String())
+
 	// Negative tests
 	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
 	assert.NotNil(t, err)
@@ -1121,13 +1209,15 @@ func TestUnmarshalPrimitiveUUID(t *testing.T) {
 		"bad_type":  true,
 		"not_a_slice": false,
 		"bad_slice_type": [38, 26],
-		"null_prop": null
+		"null_prop": null,
+		"slice_with_null": [ null, "%u1", null ]
 	}`
 
 	u1 := "63769e9f-94e6-4ab6-8c68-dd33f69fb535"
 	u2 := "e43db1b8-673a-4033-bf18-ded07172700f"
 	u3 := "7c5a5c8c-bba1-453b-8e65-c56ffd0aab07"
 	u4 := "43bde04f-5581-448e-bd51-50f554c41ac4"
+	var zeroValue strfmt.UUID
 
 	jsonString := strings.ReplaceAll(jsonTemplate, "%u1", u1)
 	jsonString = strings.ReplaceAll(jsonString, "%u2", u2)
@@ -1211,6 +1301,15 @@ func TestUnmarshalPrimitiveUUID(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, model.PropSliceMapSlice)
 
+	model.PropSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_with_null", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, 3, len(model.PropSlice))
+	assert.Equal(t, zeroValue.String(), model.PropSlice[0].String())
+	assert.Equal(t, u1, model.PropSlice[1].String())
+	assert.Equal(t, zeroValue.String(), model.PropSlice[2].String())
+
 	// Negative tests
 	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)
 	assert.NotNil(t, err)
@@ -1257,7 +1356,8 @@ func TestUnmarshalPrimitiveAny(t *testing.T) {
 		"ok_type":  true,
 		"not_a_slice": false,
 		"ok_slice_type": [38, 26],
-		"null_prop": null
+		"null_prop": null,
+		"slice_with_null": [ null, "%s1", null ]
 	}`
 
 	s1 := "value1"
@@ -1266,6 +1366,7 @@ func TestUnmarshalPrimitiveAny(t *testing.T) {
 	b1 := true
 	b2 := false
 	f1 := float64(39.0001)
+	var zeroValue interface{}
 
 	jsonString := strings.ReplaceAll(jsonTemplate, "%s1", s1)
 	jsonString = strings.ReplaceAll(jsonString, "%n1", fmt.Sprintf("%d", n1))
@@ -1349,6 +1450,15 @@ func TestUnmarshalPrimitiveAny(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, model.PropSliceMapSlice)
 
+	model.PropSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_with_null", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, 3, len(model.PropSlice))
+	assert.Equal(t, zeroValue, model.PropSlice[0])
+	assert.Equal(t, s1, model.PropSlice[1].(string))
+	assert.Equal(t, zeroValue, model.PropSlice[2])
+
 	// Negative tests
 	model.Prop = nil
 	err = UnmarshalPrimitive(rawMap, "ok_type", &model.Prop)
@@ -1366,7 +1476,7 @@ func TestUnmarshalPrimitiveAny(t *testing.T) {
 	assert.NotNil(t, model.PropSlice)
 }
 
-func TestUnmarshalPrimitiveObject(t *testing.T) {
+func TestUnmarshalPrimitiveAnyObject(t *testing.T) {
 	type MyModel struct {
 		Prop              map[string]interface{}
 		PropSlice         []map[string]interface{}
@@ -1387,11 +1497,14 @@ func TestUnmarshalPrimitiveObject(t *testing.T) {
 		"bad_type":  true,
 		"not_a_slice": false,
 		"bad_slice_type": [38, 26],
-		"null_prop": null
+		"null_prop": null,
+		"slice_with_null": [ null, %o1, null ]
 	}`
 
 	o1 := `{"field1": "value1"}`
 	o2 := `{"field2": "value2"}`
+	var zeroValue map[string]interface{}
+	o1AsAnyObject := map[string]interface{}{"field1": "value1"}
 
 	jsonString := strings.ReplaceAll(jsonTemplate, "%o1", o1)
 	jsonString = strings.ReplaceAll(jsonString, "%o2", o2)
@@ -1455,6 +1568,15 @@ func TestUnmarshalPrimitiveObject(t *testing.T) {
 	err = UnmarshalPrimitive(rawMap, "null_prop", &model.PropSliceMapSlice)
 	assert.Nil(t, err)
 	assert.Nil(t, model.PropSliceMapSlice)
+
+	model.PropSlice = nil
+	err = UnmarshalPrimitive(rawMap, "slice_with_null", &model.PropSlice)
+	assert.Nil(t, err)
+	assert.NotNil(t, model.PropSlice)
+	assert.Equal(t, 3, len(model.PropSlice))
+	assert.Equal(t, zeroValue, model.PropSlice[0])
+	assert.Equal(t, o1AsAnyObject, model.PropSlice[1])
+	assert.Equal(t, zeroValue, model.PropSlice[2])
 
 	// Negative tests
 	err = UnmarshalPrimitive(rawMap, "bad_type", &model.Prop)


### PR DESCRIPTION

This commit improves the model unmarshalling capabilities within the Go core
by adding support for an additional pattern ([][]MyModel) within the
UnmarshalModel() function.  The full set of patterns now supported are:
- MyModel (model instance)
- map[string]MyModel (map containing model instances)
- map[string][]MyModel (map contains slices of model instances
- []MyModel (slice of model instances)
- new: [][]MyModel (slice of model instance slices)