### PR TITLE
build: update golangci-lint version in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - sudo apt-get install python
 
 install:
-  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.31.0
+  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.39.0
   - curl -s https://codecov.io/bash > $HOME/codecov-bash.sh && chmod +x $HOME/codecov-bash.sh
 
 script:


### PR DESCRIPTION
## PR summary
This PR updates the version of the golangci-lint package in the travis config to fix linter errors during travis builds.

**Fixes:** https://github.ibm.com/arf/planning-sdk-squad/issues/2565