### PR TITLE
chore: ignore false positive codescan

### DIFF
--- a/v5/core/config_utils.go
+++ b/v5/core/config_utils.go
@@ -118,6 +118,7 @@ func getServicePropertiesFromCredentialFile(credentialKey string) map[string]str
 		if err != nil {
 			return nil
 		}
+		/* #nosec G307 */
 		defer file.Close()
 
 		// Collect the contents of the credential file in a string array.


### PR DESCRIPTION
This was flagged as a potential vulnerability by the ASOC scans.