### PR TITLE
fix: eliminate goroutine leak in the authenticators

### DIFF
--- a/v5/core/cp4d_authenticator.go
+++ b/v5/core/cp4d_authenticator.go
@@ -201,17 +201,7 @@ func (authenticator *CloudPakForDataAuthenticator) getToken() (string, error) {
 		}
 	} else if authenticator.getTokenData().needsRefresh() {
 		// If refresh needed, kick off a go routine in the background to get a new token
-		ch := make(chan error)
-		go func() {
-			ch <- authenticator.invokeRequestTokenData()
-		}()
-		select {
-		case err := <-ch:
-			if err != nil {
-				return "", err
-			}
-		default:
-		}
+		go authenticator.invokeRequestTokenData()
 	}
 
 	// return an error if the access token is not valid or was not fetched

--- a/v5/core/cp4d_authenticator.go
+++ b/v5/core/cp4d_authenticator.go
@@ -201,6 +201,7 @@ func (authenticator *CloudPakForDataAuthenticator) getToken() (string, error) {
 		}
 	} else if authenticator.getTokenData().needsRefresh() {
 		// If refresh needed, kick off a go routine in the background to get a new token
+		//nolint: errcheck
 		go authenticator.invokeRequestTokenData()
 	}
 

--- a/v5/core/iam_authenticator.go
+++ b/v5/core/iam_authenticator.go
@@ -213,6 +213,7 @@ func (authenticator *IamAuthenticator) getToken() (string, error) {
 		}
 	} else if authenticator.getTokenData().needsRefresh() {
 		// If refresh needed, kick off a go routine in the background to get a new token
+		//nolint: errcheck
 		go authenticator.invokeRequestTokenData()
 	}
 

--- a/v5/core/iam_authenticator.go
+++ b/v5/core/iam_authenticator.go
@@ -213,17 +213,7 @@ func (authenticator *IamAuthenticator) getToken() (string, error) {
 		}
 	} else if authenticator.getTokenData().needsRefresh() {
 		// If refresh needed, kick off a go routine in the background to get a new token
-		ch := make(chan error)
-		go func() {
-			ch <- authenticator.invokeRequestTokenData()
-		}()
-		select {
-		case err := <-ch:
-			if err != nil {
-				return "", err
-			}
-		default:
-		}
+		go authenticator.invokeRequestTokenData()
 	}
 
 	// return an error if the access token is not valid or was not fetched


### PR DESCRIPTION
This PR fixes some possible goroutine leak in the authenticators' `getToken` methods.

Closes #108 