### PR TITLE
feat: add FileWithMetadata type to the core

### DIFF
--- a/v5/core/file_with_metadata.go
+++ b/v5/core/file_with_metadata.go
@@ -1,0 +1,76 @@
+package core
+
+// (C) Copyright IBM Corp. 2021.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"reflect"
+)
+
+// FileWithMetadata : A file with its associated metadata.
+type FileWithMetadata struct {
+	// The data / content for the file.
+	Data io.ReadCloser `json:"data" validate:"required"`
+
+	// The filename of the file.
+	Filename *string `json:"filename,omitempty"`
+
+	// The content type of the file.
+	ContentType *string `json:"content_type,omitempty"`
+}
+
+// NewFileWithMetadata : Instantiate FileWithMetadata (Generic Model Constructor)
+func NewFileWithMetadata(data io.ReadCloser) (model *FileWithMetadata, err error) {
+	model = &FileWithMetadata{
+		Data: data,
+	}
+	err = ValidateStruct(model, "required parameters")
+	return
+}
+
+// UnmarshalFileWithMetadata unmarshals an instance of FileWithMetadata from the specified map of raw messages.
+// The "data" field is assumed to be a string, the value of which is assumed to be a path to the file that
+// contains the data intended for the FileWithMetadata struct.
+func UnmarshalFileWithMetadata(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(FileWithMetadata)
+
+	// unmarshal the data field as a filename and read the contents
+	// then explicitly set the Data field to the contents of the file
+	var data io.ReadCloser
+	var pathToData string
+	err = UnmarshalPrimitive(m, "data", &pathToData)
+	if err != nil {
+		return
+	}
+	data, err = os.Open(pathToData)
+	if err != nil {
+		return
+	}
+	obj.Data = data
+
+	// unmarshal the other fields as usual
+	err = UnmarshalPrimitive(m, "filename", &obj.Filename)
+	if err != nil {
+		return
+	}
+	err = UnmarshalPrimitive(m, "content_type", &obj.ContentType)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}

--- a/v5/core/file_with_metadata_test.go
+++ b/v5/core/file_with_metadata_test.go
@@ -1,0 +1,92 @@
+package core
+
+// (C) Copyright IBM Corp. 2021.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestFileWithMetadataFields(t *testing.T) {
+	data := ioutil.NopCloser(bytes.NewReader([]byte("test")))
+	filename := "test.txt"
+	contentType := "application/octet-stream"
+
+	model := FileWithMetadata{
+		Data: data,
+		Filename: &filename,
+		ContentType: &contentType,
+	}
+
+	assert.NotNil(t, model.Data)
+	assert.NotNil(t, model.Filename)
+	assert.NotNil(t, model.ContentType)
+}
+
+
+func TestNewFileWithMetadata(t *testing.T) {
+	data := ioutil.NopCloser(bytes.NewReader([]byte("test")))
+	model, err := NewFileWithMetadata(data)
+
+	assert.Nil(t, err)
+	myData, ok := model.Data.(io.ReadCloser)
+	assert.True(t, ok)
+	assert.NotNil(t, myData)
+
+	assert.Nil(t, model.Filename)
+	assert.Nil(t, model.ContentType)
+}
+
+func TestUnmarshalFileWithMetadata(t *testing.T) {
+	var err error
+
+	// setup the test by creating a temp directory and file for the unmarshaler to read
+	err = os.Mkdir("tempdir", 0755)
+	assert.Nil(t, err)
+
+	message := []byte("test")
+	err = ioutil.WriteFile("tempdir/test-file.txt", message, 0644)
+	assert.Nil(t, err)
+
+	// mock what user input would look like - a map converted from a JSON string
+	exampleJsonString := `{"data": "tempdir/test-file.txt", "filename": "test-file.txt", "content_type": "text/plain"}`
+
+	var mapifiedString map[string]json.RawMessage
+	err = json.Unmarshal([]byte(exampleJsonString), &mapifiedString);
+	assert.Nil(t, err)
+
+	var model *FileWithMetadata
+
+	err = UnmarshalFileWithMetadata(mapifiedString, &model)
+	assert.Nil(t, err)
+
+	data, ok := model.Data.(io.ReadCloser)
+	assert.True(t, ok)
+	assert.NotNil(t, data)
+
+	assert.NotNil(t, model.Filename)
+	assert.Equal(t, "test-file.txt", *model.Filename)
+
+	assert.NotNil(t, model.ContentType)
+	assert.Equal(t, "text/plain", *model.ContentType)
+
+	err = os.RemoveAll("tempdir")
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
FileWithMetadata is a struct that contains the binary data within a file, along
with specific metadata: the filename and the content type. This is a type that
the generated code occasionally uses. Currently, we generate this type as a
model on a specific service but because it is service-independent, we want to
move it to the core. This adds it as a supported type within the core. Although
the generator won't be able to change this type in options models until the next
major relase, it will use this type in the generated unmarshall functions, which
are currently broken. This will be fixed in the generator after this feature is
released.

The new "unmarshaler" in the core includes code to parse the JSON
string and read the data from the file while creating the struct. Generated
unmarshaller on service structs will invoke this new, working unmarshaller.

I have verified that this works and this PR will be a necessary dependency of my upcoming generator PR.