### PR TITLE
feat: check for empty string in ParseDate

### DIFF
--- a/v5/core/datetime.go
+++ b/v5/core/datetime.go
@@ -73,7 +73,12 @@ func NormalizeDateTimeUTC(t time.Time) time.Time {
 }
 
 // ParseDate parses the specified RFC3339 full-date string (YYYY-MM-DD) and returns a strfmt.Date instance.
+// If the string is empty the return value will be the unix epoch (1970-01-01).
 func ParseDate(dateString string) (fmtDate strfmt.Date, err error) {
+	if dateString == "" {
+		return strfmt.Date(time.Unix(0, 0).UTC()), nil
+	}
+
 	formattedTime, err := time.Parse(strfmt.RFC3339FullDate, dateString)
 	if err == nil {
 		fmtDate = strfmt.Date(formattedTime)
@@ -82,6 +87,7 @@ func ParseDate(dateString string) (fmtDate strfmt.Date, err error) {
 }
 
 // ParseDateTime parses the specified date-time string and returns a strfmt.DateTime instance.
+// If the string is empty the return value will be the unix epoch (1970-01-01T00:00:00.000Z).
 func ParseDateTime(dateString string) (strfmt.DateTime, error) {
 	return strfmt.ParseDateTime(dateString)
 }

--- a/v5/core/datetime_test.go
+++ b/v5/core/datetime_test.go
@@ -172,6 +172,10 @@ func TestDateTimeUtil(t *testing.T) {
 	assert.Equal(t, strfmt.Date{}, fmtDate)
 	assert.NotNil(t, err)
 
+	fmtDate, err = ParseDate("")
+	assert.Equal(t, strfmt.Date(time.Unix(0, 0).UTC()), fmtDate)
+	assert.Nil(t, err)
+
 	dateTimeVar := strfmt.DateTime(time.Now())
 	var fmtDTime strfmt.DateTime
 	fmtDTime, err = ParseDateTime(dateTimeVar.String())
@@ -181,4 +185,8 @@ func TestDateTimeUtil(t *testing.T) {
 	fmtDTime, err = ParseDateTime("not a datetime")
 	assert.Equal(t, strfmt.DateTime{}, fmtDTime)
 	assert.NotNil(t, err)
+
+	fmtDTime, err = ParseDateTime("")
+	assert.Equal(t, strfmt.NewDateTime(), fmtDTime)
+	assert.Nil(t, err)
 }


### PR DESCRIPTION
This PR adds empty string check to the `ParseDate` function. It's the same as the `strfmt` packages has in the `ParseDateTime` function. Tests have been updated.