### PR TITLE
fix: allow user to set "Host" request header

### DIFF
--- a/v5/core/base_service.go
+++ b/v5/core/base_service.go
@@ -306,6 +306,15 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 		for k, v := range service.DefaultHeaders {
 			req.Header.Add(k, strings.Join(v, ""))
 		}
+
+		// After adding the default headers, make one final check to see if the user
+		// specified the "Host" header within the default headers.
+		// This needs to be handled separately because it will be ignored by
+		// the Request.Write() method.
+		host := service.DefaultHeaders.Get("Host")
+		if host != "" {
+			req.Host = host
+		}
 	}
 
 	// Add the default User-Agent header if not already present.

--- a/v5/core/cp4d_authenticator_test.go
+++ b/v5/core/cp4d_authenticator_test.go
@@ -554,6 +554,7 @@ func TestCp4dUserHeaders(t *testing.T) {
 		verifyAuthRequest(t, r, "mookie", "", "King of the North")
 		assert.Equal(t, "Value1", r.Header.Get("Header1"))
 		assert.Equal(t, "Value2", r.Header.Get("Header2"))
+		assert.Equal(t, "cp4d.cloud.ibm.com", r.Host)
 
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, `{ "_messageCode_":"200", "message":"success", "token":"%s"}`, cp4dUsernameApikey1)
@@ -563,6 +564,7 @@ func TestCp4dUserHeaders(t *testing.T) {
 	headers := make(map[string]string)
 	headers["Header1"] = "Value1"
 	headers["Header2"] = "Value2"
+	headers["Host"] = "cp4d.cloud.ibm.com"
 
 	authenticator := &CloudPakForDataAuthenticator{
 		URL:      server.URL,

--- a/v5/core/iam_authenticator_test.go
+++ b/v5/core/iam_authenticator_test.go
@@ -535,12 +535,14 @@ func TestIamUserHeaders(t *testing.T) {
 		assert.False(t, ok)
 		assert.Equal(t, "Value1", r.Header.Get("Header1"))
 		assert.Equal(t, "Value2", r.Header.Get("Header2"))
+		assert.Equal(t, "iam.cloud.ibm.com", r.Host)
 	}))
 	defer server.Close()
 
 	headers := make(map[string]string)
 	headers["Header1"] = "Value1"
 	headers["Header2"] = "Value2"
+	headers["Host"] = "iam.cloud.ibm.com"
 
 	authenticator, err := NewIamAuthenticator("bogus-apikey", server.URL, "", "", false, headers)
 	assert.Nil(t, err)

--- a/v5/core/request_builder.go
+++ b/v5/core/request_builder.go
@@ -348,6 +348,13 @@ func (requestBuilder *RequestBuilder) Build() (req *http.Request, err error) {
 	// Headers
 	req.Header = requestBuilder.Header
 
+	// If "Host" was specified as a header, we need to explicitly copy it
+	// to the request's Host field since the "Host" header will be ignored by Request.Write().
+	host := req.Header.Get("Host")
+	if host != "" {
+		req.Host = host
+	}
+
 	// Query
 	query := req.URL.Query()
 	for k, l := range requestBuilder.Query {

--- a/v5/core/request_builder_test.go
+++ b/v5/core/request_builder_test.go
@@ -675,3 +675,37 @@ func TestRequestWithContextTimeout(t *testing.T) {
 	assert.Contains(t, err.Error(), "context deadline exceeded")
 	assert.Nil(t, detailedResponse)
 }
+
+func TestHostHeader1(t *testing.T) {
+	// "baseline" test to ensure that if the Host header is not explicitly set,
+	// then the host from the request URL is used.
+
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ResolveRequestURL("https://localhost:80/api/v1", "", nil)
+	assert.Nil(t, err)
+
+	req, err := builder.Build()
+	assert.Nil(t, err)
+	assert.NotNil(t, req)
+
+	assert.Equal(t, "localhost:80", req.Host)
+	t.Logf("Host: %s\n", req.Host)
+}
+
+func TestHostHeader2(t *testing.T) {
+	// Verify that if the "Host" header is set on the request builder,
+	// then the resulting Request object will have its Host field set as well.
+
+	builder := NewRequestBuilder("GET")
+	_, err := builder.ResolveRequestURL("https://localhost:80/api/v1", "", nil)
+	assert.Nil(t, err)
+
+	builder.AddHeader("Host", "overridehost:81")
+
+	req, err := builder.Build()
+	assert.Nil(t, err)
+	assert.NotNil(t, req)
+
+	assert.Equal(t, "overridehost:81", req.Host)
+	t.Logf("Host: %s\n", req.Host)
+}


### PR DESCRIPTION
The golang net/http package's Request type will ignore
the "Host" header if set in the Request.Header field.
Instead, one must explicitly set this header in the Request.Host
field.

This commit includes changes to the RequestBuilder and
BaseService types to allow a user to set "Host" in the normal
ways that an SDK user can set request headers:
- as a custom header while constructing an IAM or CP4D authenticator
- as a default header set on a service instance
- as a custom header within an options model instance when
  invoking an operation
In each of these scenarios, if the user sets the "Host" header
then the resulting Request.Host field is set with this value.
If no "Host" header is specified by the user, then Request.Host
field would be set to the host:port specified in the request URL
(the default behavior).