### PR TITLE
fix: make the get token method exported

### DIFF
--- a/v5/core/cp4d_authenticator.go
+++ b/v5/core/cp4d_authenticator.go
@@ -164,7 +164,7 @@ func (authenticator *CloudPakForDataAuthenticator) Validate() error {
 // 		Authorization: Bearer <bearer-token>
 //
 func (authenticator *CloudPakForDataAuthenticator) Authenticate(request *http.Request) error {
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	if err != nil {
 		return err
 	}
@@ -189,10 +189,10 @@ func (authenticator *CloudPakForDataAuthenticator) setTokenData(tokenData *cp4dT
 	authenticator.tokenData = tokenData
 }
 
-// getToken: returns an access token to be used in an Authorization header.
+// GetToken: returns an access token to be used in an Authorization header.
 // Whenever a new token is needed (when a token doesn't yet exist, needs to be refreshed,
 // or the existing token has expired), a new access token is fetched from the token server.
-func (authenticator *CloudPakForDataAuthenticator) getToken() (string, error) {
+func (authenticator *CloudPakForDataAuthenticator) GetToken() (string, error) {
 	if authenticator.getTokenData() == nil || !authenticator.getTokenData().isTokenValid() {
 		// synchronously request the token
 		err := authenticator.synchronizedRequestToken()

--- a/v5/core/cp4d_authenticator_test.go
+++ b/v5/core/cp4d_authenticator_test.go
@@ -187,13 +187,13 @@ func TestCp4dGetTokenSuccessPW(t *testing.T) {
 	assert.NotNil(t, authenticator)
 
 	// Force the first fetch and verify we got the correct access token back
-	accessToken, err := authenticator.getToken()
+	accessToken, err := authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, cp4dUsernamePwd1, accessToken)
 
 	// Force an expiration and verify we get back the second access token.
 	authenticator.setTokenData(nil)
-	accessToken, err = authenticator.getToken()
+	accessToken, err = authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.NotNil(t, authenticator.getTokenData())
 	assert.Equal(t, cp4dUsernamePwd2, accessToken)
@@ -221,13 +221,13 @@ func TestCp4dGetTokenSuccessAPIKey(t *testing.T) {
 	assert.NotNil(t, authenticator)
 
 	// Force the first fetch and verify we got the correct access token back
-	accessToken, err := authenticator.getToken()
+	accessToken, err := authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, cp4dUsernameApikey1, accessToken)
 
 	// Force an expiration and verify we get back the second access token.
 	authenticator.setTokenData(nil)
-	accessToken, err = authenticator.getToken()
+	accessToken, err = authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.NotNil(t, authenticator.getTokenData())
 	assert.Equal(t, cp4dUsernameApikey2, accessToken)
@@ -255,7 +255,7 @@ func TestCp4dGetCachedTokenSuccessPW(t *testing.T) {
 	assert.Nil(t, authenticator.getTokenData())
 
 	// Force the first fetch and verify we got the first access token.
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, cp4dUsernamePwd1, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -264,7 +264,7 @@ func TestCp4dGetCachedTokenSuccessPW(t *testing.T) {
 	authenticator.getTokenData().Expiration = GetCurrentTime() + 9999
 
 	// Subsequent fetch should still return first access token.
-	token, err = authenticator.getToken()
+	token, err = authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, cp4dUsernamePwd1, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -292,7 +292,7 @@ func TestCp4dGetCachedTokenAPIKey(t *testing.T) {
 	assert.Nil(t, authenticator.getTokenData())
 
 	// Force the first fetch and verify we got the first access token.
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, cp4dUsernameApikey1, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -301,7 +301,7 @@ func TestCp4dGetCachedTokenAPIKey(t *testing.T) {
 	authenticator.getTokenData().Expiration = GetCurrentTime() + 9999
 
 	// Subsequent fetch should still return first access token.
-	token, err = authenticator.getToken()
+	token, err = authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, cp4dUsernameApikey1, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -320,7 +320,7 @@ func TestCp4dGetTokenAuthFailure(t *testing.T) {
 		Password: "snow",
 	}
 
-	_, err := authenticator.getToken()
+	_, err := authenticator.GetToken()
 	assert.NotNil(t, err)
 	assert.Equal(t, "Forbidden!", err.Error())
 
@@ -352,7 +352,7 @@ func TestCp4dGetTokenDeserFailure(t *testing.T) {
 		Password: "snow",
 	}
 
-	_, err := authenticator.getToken()
+	_, err := authenticator.GetToken()
 	assert.NotNil(t, err)
 	assert.True(t, strings.HasPrefix(err.Error(), "error unmarshalling authentication response"))
 
@@ -384,7 +384,7 @@ func TestCp4dBackgroundTokenRefreshSuccess(t *testing.T) {
 	assert.Nil(t, authenticator.getTokenData())
 
 	// Force the first fetch and verify we got the first access token.
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, cp4dUsernameApikey1, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -394,16 +394,16 @@ func TestCp4dBackgroundTokenRefreshSuccess(t *testing.T) {
 	authenticator.getTokenData().RefreshTime = GetCurrentTime() - 720
 
 	// Authenticator should detect the need to refresh and request a new access token IN THE BACKGROUND when we call
-	// getToken() again. The immediate response should be the token which was already stored, since it's not yet
+	// GetToken() again. The immediate response should be the token which was already stored, since it's not yet
 	// expired.
-	token, err = authenticator.getToken()
+	token, err = authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, cp4dUsernameApikey1, token)
 	assert.NotNil(t, authenticator.getTokenData())
 
 	// Wait for the background thread to finish.
 	time.Sleep(5 * time.Second)
-	token, err = authenticator.getToken()
+	token, err = authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, cp4dUsernameApikey2, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -433,7 +433,7 @@ func TestCp4dBackgroundTokenRefreshAuthFailure(t *testing.T) {
 	assert.Nil(t, authenticator.getTokenData())
 
 	// Force the first fetch and verify we got the first access token.
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, cp4dUsernamePwd1, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -443,16 +443,16 @@ func TestCp4dBackgroundTokenRefreshAuthFailure(t *testing.T) {
 	authenticator.getTokenData().RefreshTime = GetCurrentTime() - 720
 
 	// Authenticator should detect the need to refresh and request a new access token IN THE BACKGROUND when we call
-	// getToken() again. The immediate response should be the token which was already stored, since it's not yet
+	// GetToken() again. The immediate response should be the token which was already stored, since it's not yet
 	// expired.
-	token, err = authenticator.getToken()
+	token, err = authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, cp4dUsernamePwd1, token)
 	assert.NotNil(t, authenticator.getTokenData())
 
 	// Wait for the background thread to finish
 	time.Sleep(5 * time.Second)
-	_, err = authenticator.getToken()
+	_, err = authenticator.GetToken()
 	assert.NotNil(t, err)
 	assert.Equal(t, "Forbidden!", err.Error())
 
@@ -483,7 +483,7 @@ func TestCp4dBackgroundTokenRefreshIdle(t *testing.T) {
 	assert.Nil(t, authenticator.getTokenData())
 
 	// // Force the first fetch and verify we got the first access token.
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, cp4dUsernameApikey1, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -494,8 +494,8 @@ func TestCp4dBackgroundTokenRefreshIdle(t *testing.T) {
 	authenticator.getTokenData().RefreshTime = tenMinutesBeforeNow
 
 	// Authenticator should detect the need to refresh and request a new access token IN THE BACKGROUND when we call
-	// getToken() again. The immediate response should be the token which was already stored, since it's not yet expired.
-	token, err = authenticator.getToken()
+	// GetToken() again. The immediate response should be the token which was already stored, since it's not yet expired.
+	token, err = authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, cp4dUsernameApikey1, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -507,7 +507,7 @@ func TestCp4dBackgroundTokenRefreshIdle(t *testing.T) {
 	// In the next request, the RefreshTime should be unchanged and another thread
 	// shouldn't be spawned to request another token once more since the first thread already spawned
 	// a goroutine & refreshed the token.
-	token, err = authenticator.getToken()
+	token, err = authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, cp4dUsernameApikey1, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -515,7 +515,7 @@ func TestCp4dBackgroundTokenRefreshIdle(t *testing.T) {
 
 	// Wait for the background thread to finish and verify both the RefreshTime & tokenData were updated
 	time.Sleep(5 * time.Second)
-	token, err = authenticator.getToken()
+	token, err = authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, cp4dUsernameApikey2, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -538,7 +538,7 @@ func TestCp4dDisableSSL(t *testing.T) {
 		DisableSSLVerification: true,
 	}
 
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	assert.Equal(t, cp4dUsernamePwd1, token)
 	assert.Nil(t, err)
 	assert.NotNil(t, authenticator.Client)
@@ -573,7 +573,7 @@ func TestCp4dUserHeaders(t *testing.T) {
 		Headers:  headers,
 	}
 
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	assert.Equal(t, cp4dUsernameApikey1, token)
 	assert.Nil(t, err)
 }
@@ -663,7 +663,7 @@ func TestCp4dGetTokenTimeoutError(t *testing.T) {
 	assert.Nil(t, authenticator.getTokenData())
 
 	// Force the first fetch and verify we got the first access token.
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, cp4dUsernameApikey1, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -673,7 +673,7 @@ func TestCp4dGetTokenTimeoutError(t *testing.T) {
 
 	// Set the client timeout to something very low
 	authenticator.Client.Timeout = time.Second * 2
-	token, err = authenticator.getToken()
+	token, err = authenticator.GetToken()
 	assert.Equal(t, "", token)
 	assert.NotNil(t, err)
 	assert.NotNil(t, err.Error())
@@ -704,14 +704,14 @@ func TestCp4dGetTokenServerError(t *testing.T) {
 	assert.Nil(t, authenticator.getTokenData())
 
 	// Force the first fetch and verify we got the first access token.
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, cp4dUsernamePwd1, token)
 	assert.NotNil(t, authenticator.getTokenData())
 
 	// Force expiration and verify that we got a server error.
 	authenticator.getTokenData().Expiration = GetCurrentTime() - 3600
-	token, err = authenticator.getToken()
+	token, err = authenticator.GetToken()
 	assert.NotNil(t, err)
 
 	// We expect an AuthenticationError to be returned, so cast the returned error

--- a/v5/core/iam_authenticator.go
+++ b/v5/core/iam_authenticator.go
@@ -146,7 +146,7 @@ func (*IamAuthenticator) AuthenticationType() string {
 // 		Authorization: Bearer <bearer-token>
 //
 func (authenticator *IamAuthenticator) Authenticate(request *http.Request) error {
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	if err != nil {
 		return err
 	}
@@ -201,10 +201,10 @@ func (this *IamAuthenticator) Validate() error {
 	return nil
 }
 
-// getToken: returns an access token to be used in an Authorization header.
+// GetToken: returns an access token to be used in an Authorization header.
 // Whenever a new token is needed (when a token doesn't yet exist, needs to be refreshed,
 // or the existing token has expired), a new access token is fetched from the token server.
-func (authenticator *IamAuthenticator) getToken() (string, error) {
+func (authenticator *IamAuthenticator) GetToken() (string, error) {
 	if authenticator.getTokenData() == nil || !authenticator.getTokenData().isTokenValid() {
 		// synchronously request the token
 		err := authenticator.synchronizedRequestToken()

--- a/v5/core/iam_authenticator_test.go
+++ b/v5/core/iam_authenticator_test.go
@@ -127,7 +127,7 @@ func TestIamGetTokenSuccess(t *testing.T) {
 	assert.Nil(t, authenticator.getTokenData())
 
 	// Force the first fetch and verify we got the first access token.
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, AccessToken1, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -136,7 +136,7 @@ func TestIamGetTokenSuccess(t *testing.T) {
 	authenticator.getTokenData().Expiration = GetCurrentTime() - 3600
 	authenticator.ClientId = "mookie"
 	authenticator.ClientSecret = "betts"
-	_, err = authenticator.getToken()
+	_, err = authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.NotNil(t, authenticator.getTokenData())
 	assert.Equal(t, AccessToken2, authenticator.getTokenData().AccessToken)
@@ -194,7 +194,7 @@ func TestIamGetTokenSuccessWithScope(t *testing.T) {
 	authenticator.Scope = "scope1 scope2"
 
 	// Force the first fetch and verify we got the first access token.
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, AccessToken1, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -203,7 +203,7 @@ func TestIamGetTokenSuccessWithScope(t *testing.T) {
 	authenticator.getTokenData().Expiration = GetCurrentTime() - 3600
 	authenticator.ClientId = "mookie"
 	authenticator.ClientSecret = "betts"
-	_, err = authenticator.getToken()
+	_, err = authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.NotNil(t, authenticator.getTokenData())
 	assert.Equal(t, AccessToken2, authenticator.getTokenData().AccessToken)
@@ -243,13 +243,13 @@ func TestIamGetCachedToken(t *testing.T) {
 	assert.Nil(t, authenticator.getTokenData())
 
 	// Force the first fetch and verify we got the first access token.
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, AccessToken1, token)
 	assert.NotNil(t, authenticator.getTokenData())
 
 	// Subsequent fetch should still return first access token.
-	token, err = authenticator.getToken()
+	token, err = authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, AccessToken1, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -290,7 +290,7 @@ func TestIamBackgroundTokenRefresh(t *testing.T) {
 	assert.Nil(t, authenticator.getTokenData())
 
 	// Force the first fetch and verify we got the first access token.
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, AccessToken1, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -299,16 +299,16 @@ func TestIamBackgroundTokenRefresh(t *testing.T) {
 	authenticator.getTokenData().RefreshTime = GetCurrentTime() - 720
 
 	// Authenticator should detect the need to refresh and request a new access token IN THE BACKGROUND when we call
-	// getToken() again. The immediate response should be the token which was already stored, since it's not yet
+	// GetToken() again. The immediate response should be the token which was already stored, since it's not yet
 	// expired.
-	token, err = authenticator.getToken()
+	token, err = authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, AccessToken1, token)
 	assert.NotNil(t, authenticator.getTokenData())
 
 	// Wait for the background thread to finish
 	time.Sleep(5 * time.Second)
-	token, err = authenticator.getToken()
+	token, err = authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, AccessToken2, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -341,7 +341,7 @@ func TestIamBackgroundTokenRefreshFailure(t *testing.T) {
 	assert.Nil(t, authenticator.getTokenData())
 
 	// Successfully fetch the first token.
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, AccessToken1, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -349,15 +349,15 @@ func TestIamBackgroundTokenRefreshFailure(t *testing.T) {
 	// Now put the test in the "refresh window" where the token is not expired but still needs to be refreshed.
 	authenticator.getTokenData().RefreshTime = GetCurrentTime() - 720
 	// Authenticator should detect the need to refresh and request a new access token IN THE BACKGROUND when we call
-	// getToken() again. The immediate response should be the token which was already stored, since it's not yet
+	// GetToken() again. The immediate response should be the token which was already stored, since it's not yet
 	// expired.
-	token, err = authenticator.getToken()
+	token, err = authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, AccessToken1, token)
 	assert.NotNil(t, authenticator.getTokenData())
 	// Wait for the background thread to finish
 	time.Sleep(5 * time.Second)
-	_, err = authenticator.getToken()
+	_, err = authenticator.GetToken()
 	assert.NotNil(t, err)
 	assert.Equal(t, "Error while trying to get access token", err.Error())
 	// We don't expect a AuthenticateError to be returned, so casting should fail
@@ -402,7 +402,7 @@ func TestIamBackgroundTokenRefreshIdle(t *testing.T) {
 	assert.Nil(t, authenticator.getTokenData())
 
 	// Force the first fetch and verify we got the first access token.
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, AccessToken1, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -412,9 +412,9 @@ func TestIamBackgroundTokenRefreshIdle(t *testing.T) {
 	authenticator.getTokenData().RefreshTime = tenMinutesBeforeNow
 
 	// Authenticator should detect the need to refresh and request a new access token IN THE BACKGROUND when we call
-	// getToken() again. The immediate response should be the token which was already stored, since it's not yet
+	// GetToken() again. The immediate response should be the token which was already stored, since it's not yet
 	// expired.
-	token, err = authenticator.getToken()
+	token, err = authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, AccessToken1, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -426,7 +426,7 @@ func TestIamBackgroundTokenRefreshIdle(t *testing.T) {
 	// In the next request, the RefreshTime should be unchanged and another thread
 	// shouldn't be spawned to request another token once more since the first thread already spawned
 	// a goroutine & refreshed the token.
-	token, err = authenticator.getToken()
+	token, err = authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, AccessToken1, token)
 
@@ -435,7 +435,7 @@ func TestIamBackgroundTokenRefreshIdle(t *testing.T) {
 
 	// Wait for the background thread to finish and verify both the RefreshTime & tokenData were updated
 	time.Sleep(5 * time.Second)
-	token, err = authenticator.getToken()
+	token, err = authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, AccessToken2, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -468,7 +468,7 @@ func TestIamClientIdAndSecret(t *testing.T) {
 		ClientSecret: "betts",
 	}
 
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	assert.Equal(t, accessToken, token)
 	assert.Nil(t, err)
 }
@@ -509,7 +509,7 @@ func TestIamDisableSSL(t *testing.T) {
 	authenticator, err := NewIamAuthenticator("bogus-apikey", server.URL, "", "", true, nil)
 	assert.Nil(t, err)
 
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	assert.Equal(t, accessToken, token)
 	assert.Nil(t, err)
 	assert.NotNil(t, authenticator.Client)
@@ -547,7 +547,7 @@ func TestIamUserHeaders(t *testing.T) {
 	authenticator, err := NewIamAuthenticator("bogus-apikey", server.URL, "", "", false, headers)
 	assert.Nil(t, err)
 
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	assert.Equal(t, accessToken, token)
 	assert.Nil(t, err)
 }
@@ -566,7 +566,7 @@ func TestIamGetTokenFailure(t *testing.T) {
 
 	var expectedResponse = []byte("Sorry you are forbidden")
 
-	_, err := authenticator.getToken()
+	_, err := authenticator.GetToken()
 	assert.NotNil(t, err)
 	assert.Equal(t, "Sorry you are forbidden", err.Error())
 	// We expect an AuthenticationError to be returned, so cast the returned error
@@ -617,7 +617,7 @@ func TestIamGetTokenTimeoutError(t *testing.T) {
 	assert.Nil(t, authenticator.getTokenData())
 
 	// Force the first fetch and verify we got the first access token.
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, AccessToken1, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -627,7 +627,7 @@ func TestIamGetTokenTimeoutError(t *testing.T) {
 
 	// Set the client timeout to something very low
 	authenticator.Client.Timeout = time.Second * 2
-	token, err = authenticator.getToken()
+	token, err = authenticator.GetToken()
 	assert.Empty(t, token)
 	assert.NotNil(t, err)
 	assert.NotNil(t, err.Error())
@@ -664,7 +664,7 @@ func TestIamGetTokenServerError(t *testing.T) {
 	assert.Nil(t, authenticator.getTokenData())
 
 	// Force the first fetch and verify we got the first access token.
-	token, err := authenticator.getToken()
+	token, err := authenticator.GetToken()
 	assert.Nil(t, err)
 	assert.Equal(t, AccessToken1, token)
 	assert.NotNil(t, authenticator.getTokenData())
@@ -673,7 +673,7 @@ func TestIamGetTokenServerError(t *testing.T) {
 
 	// Force expiration and verify that we got a server error
 	authenticator.getTokenData().Expiration = GetCurrentTime() - 3600
-	token, err = authenticator.getToken()
+	token, err = authenticator.GetToken()
 	assert.NotNil(t, err)
 	// We expect an AuthenticationError to be returned, so cast the returned error
 	authError, ok := err.(*AuthenticationError)


### PR DESCRIPTION
This PR renames the `getToken()` methods in the IAM authenticator and in the CP4D authenticator to `GetToken()`.