### PR TITLE
chore: reimplement a JWT function to drop the dependency

### DIFF
--- a/v5/core/jwt_utils.go
+++ b/v5/core/jwt_utils.go
@@ -15,11 +15,10 @@ package core
 // limitations under the License.
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
-
-	jwt "github.com/form3tech-oss/jwt-go"
 )
 
 // coreJWTClaims are the fields within a JWT's "claims" segment that we're interested in.
@@ -39,7 +38,7 @@ func parseJWT(tokenString string) (claims *coreJWTClaims, err error) {
 
 	// Parse Claims segment.
 	var claimBytes []byte
-	claimBytes, err = jwt.DecodeSegment(segments[1])
+	claimBytes, err = decodeSegment(segments[1])
 	if err != nil {
 		err = fmt.Errorf("error decoding claims segment: %s", err.Error())
 		return
@@ -54,4 +53,14 @@ func parseJWT(tokenString string) (claims *coreJWTClaims, err error) {
 	}
 
 	return
+}
+
+// Decode JWT specific base64url encoding with padding stripped
+// Copied from https://github.com/golang-jwt/jwt/blob/main/token.go
+func decodeSegment(seg string) ([]byte, error) {
+	if l := len(seg) % 4; l > 0 {
+		seg += strings.Repeat("=", 4-l)
+	}
+
+	return base64.URLEncoding.DecodeString(seg)
 }

--- a/v5/core/jwt_utils_test.go
+++ b/v5/core/jwt_utils_test.go
@@ -75,6 +75,6 @@ func TestDecodeSegment(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, []byte{}, decoded)
 
-	decoded, err = decodeSegment(testStringInvalid)
+	_, err = decodeSegment(testStringInvalid)
 	assert.NotNil(t, err)
 }

--- a/v5/core/jwt_utils_test.go
+++ b/v5/core/jwt_utils_test.go
@@ -53,3 +53,28 @@ func TestParseJWT(t *testing.T) {
 	assert.Equal(t, int64(1610591412), claims.ExpiresAt)
 	assert.Equal(t, int64(1610548248), claims.IssuedAt)
 }
+
+func TestDecodeSegment(t *testing.T) {
+	testStringDecoded := "testString\n"
+	testStringEncoded := "dGVzdFN0cmluZwo="
+	testStringEncodedShort := "dGVzdFN0cmluZwo"
+	testStringInvalid := "???!"
+
+	var err error
+	var decoded []byte
+
+	decoded, err = decodeSegment(testStringEncoded)
+	assert.Nil(t, err)
+	assert.Equal(t, testStringDecoded, string(decoded))
+
+	decoded, err = decodeSegment(testStringEncodedShort)
+	assert.Nil(t, err)
+	assert.Equal(t, testStringDecoded, string(decoded))
+
+	decoded, err = decodeSegment("")
+	assert.Nil(t, err)
+	assert.Equal(t, []byte{}, decoded)
+
+	decoded, err = decodeSegment(testStringInvalid)
+	assert.NotNil(t, err)
+}

--- a/v5/go.mod
+++ b/v5/go.mod
@@ -3,7 +3,6 @@ module github.com/IBM/go-sdk-core/v5
 go 1.12
 
 require (
-	github.com/form3tech-oss/jwt-go v3.2.2+incompatible
 	github.com/go-openapi/strfmt v0.20.1
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1

--- a/v5/go.sum
+++ b/v5/go.sum
@@ -6,8 +6,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
-github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=


### PR DESCRIPTION
This PR implements the `decodeSegment()` function from the JWT package that we have been using and also completely removes the JWT dependency from the project.

Ref: #121 