### PR TITLE
fix: error message used by CR Authenticator

### DIFF
--- a/v5/core/constants.go
+++ b/v5/core/constants.go
@@ -57,6 +57,7 @@ const (
 	ERRORMSG_PROP_MISSING            = "The %s property is required but was not specified."
 	ERRORMSG_PROP_INVALID            = "The %s property is invalid. Please remove any surrounding {, }, or \" characters."
 	ERRORMSG_EXCLUSIVE_PROPS_ERROR   = "Exactly one of %s or %s must be specified."
+	ERRORMSG_ATLEAST_ONE_PROP_ERROR  = "At least one of %s or %s must be specified."
 	ERRORMSG_NO_AUTHENTICATOR        = "Authentication information was not properly configured."
 	ERRORMSG_AUTHTYPE_UNKNOWN        = "Unrecognized authentication type: %s"
 	ERRORMSG_PROPS_MAP_NIL           = "The 'properties' map cannot be nil."

--- a/v5/core/cr_authenticator.go
+++ b/v5/core/cr_authenticator.go
@@ -210,7 +210,7 @@ func (authenticator *ComputeResourceAuthenticator) Validate() error {
 
 	// Check to make sure that one of IAMProfileName or IAMProfileID are specified.
 	if authenticator.IAMProfileName == "" && authenticator.IAMProfileID == "" {
-		return fmt.Errorf(ERRORMSG_EXCLUSIVE_PROPS_ERROR, "IAMProfileName", "IAMProfileID")
+		return fmt.Errorf(ERRORMSG_ATLEAST_ONE_PROP_ERROR, "IAMProfileName", "IAMProfileID")
 	}
 
 	// Validate ClientId and ClientSecret.  They must both be specified togther or neither should be specified.


### PR DESCRIPTION
This commit changes the error message used by the
ComputeResourceAuthenticator to report a validation
error when neither of the `IAMProfileName` or `IAMProfileID`
properties are specified by the user.
The error message is now:
`At least one of IAMProfileName or IAMProfileID must be specified.`