### PR TITLE
docs: fix some container auth references

### DIFF
--- a/Authentication.md
+++ b/Authentication.md
@@ -3,7 +3,7 @@ The go-sdk-core project supports the following types of authentication:
 - Basic Authentication
 - Bearer Token Authentication
 - Identity and Access Management (IAM) Authentication
-- Compute Resource Authentication
+- Container Authentication
 - Cloud Pak for Data Authentication
 - No Authentication
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ go get -u github.com/IBM/go-sdk-core/...
 ## Authentication
 The go-sdk-core project supports the following types of authentication:
 - Basic Authentication
-- Bearer Token 
+- Bearer Token
 - Identity and Access Management (IAM)
 - Cloud Pak for Data
+- Container
 - No Authentication
 
 For more information about the various authentication types and how to use them with your services, click [here](Authentication.md)


### PR DESCRIPTION
This PR fixes 2 minor documentation issues:
- `README.md`: missing Container auth from the `Authentication` section
- Old reference in the `Authentication.md`: Compute Resource instead Container