### PR TITLE
chore: codescan updates

### DIFF
--- a/v5/core/constants.go
+++ b/v5/core/constants.go
@@ -75,6 +75,6 @@ const (
 	ERRORMSG_CREATE_RETRYABLE_REQ    = "An error occurred while creating a retryable http Request: %s"
 	ERRORMSG_UNEXPECTED_STATUS_CODE  = "Unexpected HTTP status code %d (%s)"
 	ERRORMSG_UNMARSHAL_AUTH_RESPONSE = "error unmarshalling authentication response: %s"
-	ERRORMSG_UNABLE_RETRIEVE_CRTOKEN = "unable to retrieve compute resource token value: %s"
+	ERRORMSG_UNABLE_RETRIEVE_CRTOKEN = "unable to retrieve compute resource token value: %s" // #nosec G101
 	ERRORMSG_IAM_GETTOKEN_ERROR      = "IAM 'get token' error, status code %d received from '%s': %s" // #nosec G101
 )

--- a/v5/core/container_authenticator.go
+++ b/v5/core/container_authenticator.go
@@ -404,7 +404,8 @@ func (authenticator *ContainerAuthenticator) RequestToken() (*IamTokenServerResp
 		// If the user told us to disable SSL verification, then do it now.
 		if authenticator.DisableSSLVerification {
 			transport := &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402
+				/* #nosec G402 */
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			}
 			authenticator.Client.Transport = transport
 		}

--- a/v5/core/cp4d_authenticator.go
+++ b/v5/core/cp4d_authenticator.go
@@ -302,7 +302,8 @@ func (authenticator *CloudPakForDataAuthenticator) requestToken() (tokenResponse
 		// If the user told us to disable SSL verification, then do it now.
 		if authenticator.DisableSSLVerification {
 			transport := &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402
+				/* #nosec G402 */
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			}
 			authenticator.Client.Transport = transport
 		}

--- a/v5/core/iam_authenticator.go
+++ b/v5/core/iam_authenticator.go
@@ -308,7 +308,8 @@ func (authenticator *IamAuthenticator) RequestToken() (*IamTokenServerResponse, 
 		// If the user told us to disable SSL verification, then do it now.
 		if authenticator.DisableSSLVerification {
 			transport := &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402
+				/* #nosec G402 */
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			}
 			authenticator.Client.Transport = transport
 		}


### PR DESCRIPTION
The [`nosec` annotations](https://github.com/securego/gosec#annotating-code) are not processed when the preceding content is followed by a comma.  I tried several permutations to see if I could get around this, but was unsuccessful.