### PR TITLE
build: build on go 1.12 and 1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: go
 
-dist: xenial
+dist: bionic
 
 go:
-- 1.12.x
+- '1.12.x'
+- '1.16.x'
 
 notifications:
   email: false
@@ -43,4 +44,5 @@ deploy:
     script: npx semantic-release
     skip_cleanup: true
     on:
+      go: '1.12.x'
       branch: main

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ lint:
 	cd ${VDIR} && golangci-lint run --build-tags=all
 
 scan-gosec:
-	gosec ./...
+	cd ${VDIR} && gosec ./...
 
 tidy:
 	cd ${VDIR} && go mod tidy


### PR DESCRIPTION
This PR updates the go core build so that it is built on go 1.12 and 1.16.