### PR TITLE
build: add go 1.17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: bionic
 go:
 - '1.12.x'
 - '1.16.x'
+- '1.17.x'
 
 notifications:
   email: false


### PR DESCRIPTION
In my previous PR where I added a build job for go 1.16, I should have also added 1.17.  My bad :)