### PR TITLE
fix: handle the error during gzip compression instead of panic

### DIFF
--- a/v5/core/gzip.go
+++ b/v5/core/gzip.go
@@ -41,7 +41,7 @@ func NewGzipCompressionReader(uncompressedReader io.Reader) (io.Reader, error) {
 		// to the pipe only when the pipe reader is called to retrieve more bytes.
 		_, err := io.Copy(compressedWriter, uncompressedReader)
 		if err != nil {
-			pipeWriter.CloseWithError(err)
+			_ = pipeWriter.CloseWithError(err)
 		}
 	}()
 	return pipeReader, nil

--- a/v5/core/gzip.go
+++ b/v5/core/gzip.go
@@ -41,7 +41,7 @@ func NewGzipCompressionReader(uncompressedReader io.Reader) (io.Reader, error) {
 		// to the pipe only when the pipe reader is called to retrieve more bytes.
 		_, err := io.Copy(compressedWriter, uncompressedReader)
 		if err != nil {
-			panic(err)
+			pipeWriter.CloseWithError(err)
 		}
 	}()
 	return pipeReader, nil


### PR DESCRIPTION
This PR fixes/improves the error handling in the Gzip compression. Before this commit if an error occurred during the compression it caused a panic. With this change, in case of errors, the pipe will be closed and the error will be passed.