### PR TITLE
fix: recognize vendor-specific JSON mimetypes

### DIFF
--- a/v5/core/constants.go
+++ b/v5/core/constants.go
@@ -66,7 +66,7 @@ const (
 		"and/or use the DisableSSLVerification option of the authenticator."
 	ERRORMSG_AUTHENTICATE_ERROR      = "An error occurred while performing the 'authenticate' step: %s"
 	ERRORMSG_READ_RESPONSE_BODY      = "An error occurred while reading the response body: %s"
-	ERRORMSG_UNEXPECTED_RESPONSE     = "The response contained unexpected content"
+	ERRORMSG_UNEXPECTED_RESPONSE     = "The response contained unexpected content, Content-Type=%s, operation resultType=%s"
 	ERRORMSG_UNMARSHAL_RESPONSE_BODY = "An error occurred while unmarshalling the response body: %s"
 	ERRORMSG_NIL_SLICE               = "The 'slice' parameter cannot be nil"
 	ERRORMSG_PARAM_NOT_SLICE         = "The 'slice' parameter must be a slice"
@@ -75,6 +75,6 @@ const (
 	ERRORMSG_CREATE_RETRYABLE_REQ    = "An error occurred while creating a retryable http Request: %s"
 	ERRORMSG_UNEXPECTED_STATUS_CODE  = "Unexpected HTTP status code %d (%s)"
 	ERRORMSG_UNMARSHAL_AUTH_RESPONSE = "error unmarshalling authentication response: %s"
-	ERRORMSG_UNABLE_RETRIEVE_CRTOKEN = "unable to retrieve compute resource token value: %s" // #nosec G101
+	ERRORMSG_UNABLE_RETRIEVE_CRTOKEN = "unable to retrieve compute resource token value: %s"          // #nosec G101
 	ERRORMSG_IAM_GETTOKEN_ERROR      = "IAM 'get token' error, status code %d received from '%s': %s" // #nosec G101
 )

--- a/v5/core/utils.go
+++ b/v5/core/utils.go
@@ -40,7 +40,7 @@ func init() {
 }
 
 const (
-	jsonMimePattern      = "(?i)^application\\/((json)|(merge\\-patch\\+json))(;.*)?$"
+	jsonMimePattern      = "(?i)^application\\/((json)|(merge\\-patch\\+json)|(vnd\\..*\\+json))(;.*)?$"
 	jsonPatchMimePattern = "(?i)^application\\/json\\-patch\\+json(;.*)?$"
 )
 

--- a/v5/core/utils_test.go
+++ b/v5/core/utils_test.go
@@ -29,9 +29,13 @@ func TestIsJSONMimeType(t *testing.T) {
 	assert.True(t, IsJSONMimeType("application/json"))
 	assert.True(t, IsJSONMimeType("APPlication/json"))
 	assert.True(t, IsJSONMimeType("application/json;blah"))
+	assert.True(t, IsJSONMimeType("application/vnd.docker.distribution.manifest.v2+json"))
+	assert.True(t, IsJSONMimeType("application/vnd.anothervendor.custom.semantics+json"))
+	assert.True(t, IsJSONMimeType("application/vnd.yet.another.vendor.with.custom.semantics.blah.v3+json;charset=UTF8"))
 
 	assert.False(t, IsJSONMimeType("application/json-patch+patch"))
 	assert.False(t, IsJSONMimeType("YOapplication/jsonYO"))
+	assert.False(t, IsJSONMimeType("YOapplication/vnd.docker.distribution.manifest.v2+jsonYO"))
 }
 
 func TestIsJSONPatchMimeType(t *testing.T) {


### PR DESCRIPTION
This commit modifies the Go core response-handling code
so that it recognizes vendor-specific JSON-based mimetypes
(e.g. application/vnd.docker.distribution.manifest.v2+json)
as being equivalent to "application/json" when deciding how
to unmarshal an operation response body.
Prior to this change, the Go core would treat such a response
as an error.