### PR TITLE
fix: use consistent retry behavior for 5xx status codes

### DIFF
--- a/v5/core/base_service.go
+++ b/v5/core/base_service.go
@@ -690,16 +690,9 @@ func IBMCloudSDKRetryPolicy(ctx context.Context, resp *http.Response, err error)
 	// Now check the status code.
 
 	// A 429 should be retryable.
-	if resp.StatusCode == 429 {
+	// All codes in the 500's range except for 501 (Not Implemented) should be retryable.
+	if resp.StatusCode == 429 || (resp.StatusCode >= 500 && resp.StatusCode <= 599 && resp.StatusCode != 501) {
 		return true, nil
-	}
-
-	// Check the response code. We retry on 500-range responses to allow
-	// the server time to recover, as 500's are typically not permanent
-	// errors and may relate to outages on the server side. This will catch
-	// invalid response codes as well, like 0 and 999.
-	if resp.StatusCode == 0 || (resp.StatusCode >= 500 && resp.StatusCode != 501) {
-		return true, fmt.Errorf(ERRORMSG_UNEXPECTED_STATUS_CODE, resp.StatusCode, resp.Status)
 	}
 
 	return false, nil


### PR DESCRIPTION
This commit modifies the Go core's IBMCloudSDKRetryPolicy()
function so that retries associated with 5xx status codes
will behave the same as (for example) a 429 status code.
Specifically, this means that when retries are exhausted
as the result of a 5xx status code, the Go core will return
a non-nil DetailedResponse object, similar to a 429 status
code and also similar to a "retries disabled" scenario.
Previously, a request such as this would result in a non-nil
error return value, but a nil DetailedResponse so it was
impossible for the caller to inspect the response status code
and response headers.