### PR TITLE
chore: add .cveignore

### DIFF
--- a/.cra/.cveignore
+++ b/.cra/.cveignore
@@ -1,0 +1,6 @@
+[
+    {
+        "cve": "SNYK-GOLANG-GITHUBCOMGOBUFFALOPACKRV2-1920670",
+        "alwaysOmit": true
+    }
+]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-10-26T19:33:18Z",
+  "generated_at": "2021-11-18T23:42:27Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -108,7 +108,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 568,
+        "line_number": 575,
         "type": "Secret Keyword",
         "verified_result": null
       }


### PR DESCRIPTION
Ignores the packr/v2 vulnerability until we can put a fix in place.