### PR TITLE
fix: avoid false positive gosec errors

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-11-25T15:56:07Z",
+  "generated_at": "2021-12-10T20:12:59Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -116,7 +116,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 589,
+        "line_number": 596,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -484,7 +484,7 @@
         "hashed_secret": "7a5d27bcb7a1e98b6e1bfca4df223ed578a47283",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 97,
+        "line_number": 93,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -492,7 +492,7 @@
         "hashed_secret": "c2df5d3d760ff42f33fb38e2534d4c1b7ddde3ab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 97,
+        "line_number": 93,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -500,7 +500,7 @@
         "hashed_secret": "8b142a91cfb6e617618ad437cedf74a6745f8926",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 133,
+        "line_number": 129,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -566,7 +566,7 @@
         "hashed_secret": "32e8612d8ca77c7ea8374aa7918db8e5df9252ed",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1047,
+        "line_number": 1064,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 
 install:
   - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.41.1
-  - curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.8.1
+  - curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
 
 script:
   - make all

--- a/v5/core/container_authenticator.go
+++ b/v5/core/container_authenticator.go
@@ -404,7 +404,7 @@ func (authenticator *ContainerAuthenticator) RequestToken() (*IamTokenServerResp
 		// If the user told us to disable SSL verification, then do it now.
 		if authenticator.DisableSSLVerification {
 			transport := &http.Transport{
-				/* #nosec G402 */
+				// #nosec G402
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			}
 			authenticator.Client.Transport = transport

--- a/v5/core/cp4d_authenticator.go
+++ b/v5/core/cp4d_authenticator.go
@@ -303,7 +303,7 @@ func (authenticator *CloudPakForDataAuthenticator) requestToken() (tokenResponse
 		// If the user told us to disable SSL verification, then do it now.
 		if authenticator.DisableSSLVerification {
 			transport := &http.Transport{
-				/* #nosec G402 */
+				// #nosec G402
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			}
 			authenticator.Client.Transport = transport

--- a/v5/core/iam_authenticator.go
+++ b/v5/core/iam_authenticator.go
@@ -412,7 +412,7 @@ func (authenticator *IamAuthenticator) RequestToken() (*IamTokenServerResponse, 
 		// If the user told us to disable SSL verification, then do it now.
 		if authenticator.DisableSSLVerification {
 			transport := &http.Transport{
-				/* #nosec G402 */
+				// #nosec G402
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			}
 			authenticator.Client.Transport = transport


### PR DESCRIPTION
This PR tweaks a few of the inline code annotations used to ignore false-positive gosec violations.