### PR TITLE
refactor: use sync.Once to initialize auth http clients

### DIFF
--- a/v5/core/iam_authenticator.go
+++ b/v5/core/iam_authenticator.go
@@ -75,7 +75,8 @@ type IamAuthenticator struct {
 
 	// [Optional] The http.Client object used to invoke token server requests.
 	// If not specified by the user, a suitable default Client will be constructed.
-	Client *http.Client
+	Client     *http.Client
+	clientInit sync.Once
 
 	// The cached token and expiration time.
 	tokenData *iamTokenData
@@ -165,6 +166,26 @@ func (builder *IamAuthenticatorBuilder) Build() (*IamAuthenticator, error) {
 	}
 
 	return &builder.IamAuthenticator, nil
+}
+
+// client returns the authenticator's http client after potentially initializing it.
+func (authenticator *IamAuthenticator) client() *http.Client {
+	authenticator.clientInit.Do(func() {
+		if authenticator.Client == nil {
+			authenticator.Client = DefaultHTTPClient()
+			authenticator.Client.Timeout = time.Second * 30
+
+			// If the user told us to disable SSL verification, then do it now.
+			if authenticator.DisableSSLVerification {
+				transport := &http.Transport{
+					// #nosec G402
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				}
+				authenticator.Client.Transport = transport
+			}
+		}
+	})
+	return authenticator.Client
 }
 
 // NewIamAuthenticator constructs a new IamAuthenticator instance.
@@ -423,22 +444,6 @@ func (authenticator *IamAuthenticator) RequestToken() (*IamTokenServerResponse, 
 		req.SetBasicAuth(authenticator.ClientId, authenticator.ClientSecret)
 	}
 
-	// If the authenticator does not have a Client, create one now.
-	if authenticator.Client == nil {
-		authenticator.Client = &http.Client{
-			Timeout: time.Second * 30,
-		}
-
-		// If the user told us to disable SSL verification, then do it now.
-		if authenticator.DisableSSLVerification {
-			transport := &http.Transport{
-				// #nosec G402
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			}
-			authenticator.Client.Transport = transport
-		}
-	}
-
 	// If debug is enabled, then dump the request.
 	if GetLogger().IsLogLevelEnabled(LevelDebug) {
 		buf, dumpErr := httputil.DumpRequestOut(req, req.Body != nil)
@@ -450,7 +455,7 @@ func (authenticator *IamAuthenticator) RequestToken() (*IamTokenServerResponse, 
 	}
 
 	GetLogger().Debug("Invoking IAM 'get token' operation: %s", builder.URL)
-	resp, err := authenticator.Client.Do(req)
+	resp, err := authenticator.client().Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/v5/core/vpc_instance_authenticator.go
+++ b/v5/core/vpc_instance_authenticator.go
@@ -127,9 +127,8 @@ func (builder *VpcInstanceAuthenticatorBuilder) Build() (*VpcInstanceAuthenticat
 func (authenticator *VpcInstanceAuthenticator) client() *http.Client {
 	authenticator.clientInit.Do(func() {
 		if authenticator.Client == nil {
-			authenticator.Client = &http.Client{
-				Timeout: vpcauthDefaultTimeout,
-			}
+			authenticator.Client = DefaultHTTPClient()
+			authenticator.Client.Timeout = vpcauthDefaultTimeout
 		}
 	})
 	return authenticator.Client


### PR DESCRIPTION
This commit modifies the Container, CP4D, and IAM
authenticators so that they are all consistent with the
VPC authenticator in the way in which they obtain an
HTTP client instance for invoking operations.