### PR TITLE
build: remove Go 1.14 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 dist: bionic
 
 go:
-- '1.14.x'
 - '1.16.x'
 - '1.17.x'
 - '1.18.x'
@@ -40,5 +39,5 @@ deploy:
     script: npx semantic-release
     skip_cleanup: true
     on:
-      go: '1.14.x'
+      go: '1.16.x'
       branch: main

--- a/v5/core/base_service.go
+++ b/v5/core/base_service.go
@@ -21,7 +21,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -436,7 +436,7 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 			var readErr error
 
 			defer httpResponse.Body.Close()
-			responseBody, readErr = ioutil.ReadAll(httpResponse.Body)
+			responseBody, readErr = io.ReadAll(httpResponse.Body)
 			if readErr != nil {
 				err = fmt.Errorf(ERRORMSG_READ_RESPONSE_BODY, readErr.Error())
 				return
@@ -483,7 +483,7 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 
 			// First, read the response body into a byte array.
 			defer httpResponse.Body.Close()
-			responseBody, readErr := ioutil.ReadAll(httpResponse.Body)
+			responseBody, readErr := io.ReadAll(httpResponse.Body)
 			if readErr != nil {
 				err = fmt.Errorf(ERRORMSG_READ_RESPONSE_BODY, readErr.Error())
 				return

--- a/v5/core/base_service_test.go
+++ b/v5/core/base_service_test.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -208,7 +207,7 @@ func TestRequestGoodResponseJSONStream(t *testing.T) {
 	assert.NotNil(t, result)
 
 	// Read the bytes from the response body and decode as JSON to verify.
-	responseBytes, err := ioutil.ReadAll(result)
+	responseBytes, err := io.ReadAll(result)
 	assert.Nil(t, err)
 	assert.NotNil(t, responseBytes)
 
@@ -285,7 +284,7 @@ func TestRequestGoodResponseStream(t *testing.T) {
 	assert.NotNil(t, result)
 
 	// Read the bytes from the response body and verify.
-	actualResponse, err := ioutil.ReadAll(result)
+	actualResponse, err := io.ReadAll(result)
 	assert.Nil(t, err)
 	assert.NotNil(t, actualResponse)
 	assert.Equal(t, expectedResponse, actualResponse)
@@ -404,7 +403,7 @@ func TestRequestGoodResponseNonJSONNoContentType(t *testing.T) {
 	assert.NotNil(t, result)
 
 	// Read the bytes from the response body and verify.
-	actualResponse, err := ioutil.ReadAll(result)
+	actualResponse, err := io.ReadAll(result)
 	assert.Nil(t, err)
 	assert.NotNil(t, actualResponse)
 	assert.Equal(t, expectedResponse, actualResponse)
@@ -1324,7 +1323,7 @@ func TestRequestIAMAuth(t *testing.T) {
 	firstCall := true
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		body, _ := ioutil.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
 		if strings.Contains(string(body), "grant_type") {
 			assert.Equal(t, true, firstCall)
 			firstCall = false
@@ -1454,7 +1453,7 @@ func TestRequestIAMFailureRetryAfter(t *testing.T) {
 func TestRequestIAMWithIdSecret(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		body, _ := ioutil.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
 		if strings.Contains(string(body), "grant_type") {
 			fmt.Fprint(w, `{
                 "access_token": "captain marvel",

--- a/v5/core/config_utils_test.go
+++ b/v5/core/config_utils_test.go
@@ -1,3 +1,4 @@
+//go:build all || fast || basesvc
 // +build all fast basesvc
 
 package core
@@ -17,7 +18,6 @@ package core
 // limitations under the License.
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -30,7 +30,7 @@ const vcapServicesKey = "VCAP_SERVICES"
 
 // Sets a test VCAP_SERVICES value in the environment for testing.
 func setTestVCAP(t *testing.T) {
-	data, err := ioutil.ReadFile("../resources/vcap_services.json")
+	data, err := os.ReadFile("../resources/vcap_services.json")
 	if assert.Nil(t, err) {
 		os.Setenv(vcapServicesKey, string(data))
 	}

--- a/v5/core/container_authenticator.go
+++ b/v5/core/container_authenticator.go
@@ -19,9 +19,9 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -490,7 +490,7 @@ func (authenticator *ContainerAuthenticator) retrieveCRToken() (crToken string, 
 
 	// Read the entire file into a byte slice, then convert to string.
 	var bytes []byte
-	bytes, err = ioutil.ReadFile(crTokenFilename) // #nosec G304
+	bytes, err = os.ReadFile(crTokenFilename) // #nosec G304
 	if err != nil {
 		err = fmt.Errorf(ERRORMSG_UNABLE_RETRIEVE_CRTOKEN, err.Error())
 		GetLogger().Debug(err.Error())

--- a/v5/core/cp4d_authenticator_test.go
+++ b/v5/core/cp4d_authenticator_test.go
@@ -1,3 +1,4 @@
+//go:build all || slow || auth
 // +build all slow auth
 
 package core
@@ -19,7 +20,7 @@ package core
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -55,7 +56,7 @@ const (
 // getJSONRequestBody unmarshals the body contained in 'req' into 'result'
 func getJSONRequestBody(req *http.Request, result interface{}) error {
 	defer req.Body.Close()
-	buf, err := ioutil.ReadAll(req.Body)
+	buf, err := io.ReadAll(req.Body)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR removes Go 1.14 from the project and
updates [deprecated](https://tip.golang.org/doc/go1.16#ioutil) package imports. 