### PR TITLE
feat: add function GetQueryParamAsInt

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-03-23T14:25:50Z",
+  "generated_at": "2022-05-09T17:08:34Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -116,7 +116,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 624,
+        "line_number": 631,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -338,7 +338,7 @@
         "hashed_secret": "3c81615afb40d1889fc2e1fff551a8b59b4e80ce",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 97,
+        "line_number": 98,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -346,7 +346,7 @@
         "hashed_secret": "8b142a91cfb6e617618ad437cedf74a6745f8926",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 140,
+        "line_number": 141,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -390,7 +390,7 @@
         "hashed_secret": "f75b33f87ffeacb3a4f793a09693e672e07449ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 101,
+        "line_number": 102,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "84ed7427f222c7a1f43567e1bb3058365a81bbcb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 267,
+        "line_number": 288,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "d4a9d12d425a0edaf333f49c6004b6d417eeb87b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 268,
+        "line_number": 289,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -500,7 +500,7 @@
         "hashed_secret": "7a5d27bcb7a1e98b6e1bfca4df223ed578a47283",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 94,
+        "line_number": 95,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -508,7 +508,7 @@
         "hashed_secret": "c2df5d3d760ff42f33fb38e2534d4c1b7ddde3ab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 94,
+        "line_number": 95,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -516,7 +516,7 @@
         "hashed_secret": "8b142a91cfb6e617618ad437cedf74a6745f8926",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 130,
+        "line_number": 131,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -642,7 +642,7 @@
         "hashed_secret": "0266262f439c732a31b9353ced05c9e777a07c54",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 599,
+        "line_number": 657,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/v5/core/utils.go
+++ b/v5/core/utils.go
@@ -266,28 +266,49 @@ func SliceContains(slice []string, contains string) bool {
 	return false
 }
 
-// GetQueryParam() returns a pointer to the value of query parameter `param` from urlStr,
+// GetQueryParam returns a pointer to the value of query parameter `param` from urlStr,
 // or nil if not found.
-func GetQueryParam(urlStr *string, param string) (*string, error) {
+func GetQueryParam(urlStr *string, param string) (value *string, err error) {
 	if urlStr == nil || *urlStr == "" {
-		return nil, nil
+		return
 	}
 
-	u, err := url.Parse(*urlStr)
+	urlObj, err := url.Parse(*urlStr)
 	if err != nil {
-		return nil, err
+		return
 	}
 
-	q, err := url.ParseQuery(u.RawQuery)
+	query, err := url.ParseQuery(urlObj.RawQuery)
 	if err != nil {
-		return nil, err
+		return
 	}
 
-	v := q.Get(param)
+	v := query.Get(param)
 	if v == "" {
-		return nil, nil
+		return
 	}
-	return &v, nil
+
+	value = &v
+
+	return
+}
+
+// GetQueryParamAsInt returns a pointer to the value of query parameter `param` from urlStr
+// converted to an int64 value, or nil if not found.
+func GetQueryParamAsInt(urlStr *string, param string) (value *int64, err error) {
+	strValue, err := GetQueryParam(urlStr, param)
+	if err != nil || strValue == nil {
+		return
+	}
+
+	intValue, err := strconv.ParseInt(*strValue, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	value = &intValue
+
+	return
 }
 
 // Pre-compiled regular expressions used by RedactSecrets().

--- a/v5/go.sum
+++ b/v5/go.sum
@@ -102,7 +102,6 @@ golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f h1:rlezHXNlxYWvBCzNses9Dlc7nGFaNMJeqLolcmQSSZY=
 golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -114,7 +113,6 @@ golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190531172133-b3315ee88b7d/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=


### PR DESCRIPTION
This commit introduces the "GetQueryParamAsInt()"
utility function that will be used by generated
code to perform automatic pagination.
Similar to GetQueryParam, but also converts
the retrieved value to an int64.