### PR TITLE
build: add Go 1.19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go:
 - '1.16.x'
 - '1.17.x'
 - '1.18.x'
+- '1.19.x'
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - sudo apt-get update
 
 install:
-  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.45.2
+  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.49.0
   - curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
 
 script:


### PR DESCRIPTION
This commit enables building the project on Go 1.19.
It also updates the `golangci-lint` package version
to resolve a compatibility issue with the latest Go version.

Signed-off-by: Norbert Biczo <pyrooka@users.noreply.github.com>