### PR TITLE
feat(utils): add helper for creating a byte array pointer

### DIFF
--- a/v5/core/utils.go
+++ b/v5/core/utils.go
@@ -115,6 +115,11 @@ func UUIDPtr(literal strfmt.UUID) *strfmt.UUID {
 	return &literal
 }
 
+// ByteArrayPtr returns a pointer to []byte literal.
+func ByteArrayPtr(literal []byte) *[]byte {
+	return &literal
+}
+
 // IsJSONMimeType Returns true iff the specified mimeType value represents a
 // "JSON" mimetype.
 func IsJSONMimeType(mimeType string) bool {

--- a/v5/core/utils_test.go
+++ b/v5/core/utils_test.go
@@ -286,6 +286,9 @@ func TestPointers(t *testing.T) {
 
 	var uuidVar = strfmt.UUID("12345678-1234-1234-1234-123456123456")
 	assert.Equal(t, &uuidVar, UUIDPtr(uuidVar))
+
+	var byteArrayVar = []byte(str)
+	assert.Equal(t, &byteArrayVar, ByteArrayPtr(byteArrayVar))
 }
 
 func TestConvertSliceFloat64(t *testing.T) {


### PR DESCRIPTION
We have pointer-creation functions for a few other types. There is now a need to have a function like this for byte arrays within our generated Terraform code, so I've added it alongside the others.

Signed-off-by: Dustin Popp <dpopp07@gmail.com>