### PR TITLE
fix: BaseService.Request invoked without result does not close http.Response

### DIFF
--- a/v5/core/base_service.go
+++ b/v5/core/base_service.go
@@ -387,7 +387,7 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 
 	// If debug is enabled, then dump the request.
 	if GetLogger().IsLogLevelEnabled(LevelDebug) {
-		buf, dumpErr := httputil.DumpRequestOut(req, req.Body != nil)
+		buf, dumpErr := httputil.DumpRequestOut(req, !IsNil(req.Body))
 		if dumpErr == nil {
 			GetLogger().Debug("Request:\n%s\n", RedactSecrets(string(buf)))
 		} else {
@@ -407,7 +407,7 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 
 	// If debug is enabled, then dump the response.
 	if GetLogger().IsLogLevelEnabled(LevelDebug) {
-		buf, dumpErr := httputil.DumpResponse(httpResponse, httpResponse.Body != nil)
+		buf, dumpErr := httputil.DumpResponse(httpResponse, !IsNil(httpResponse.Body))
 		if err == nil {
 			GetLogger().Debug("Response:\n%s\n", RedactSecrets(string(buf)))
 		} else {
@@ -430,7 +430,7 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 		var responseBody []byte
 
 		// First, read the response body into a byte array.
-		if httpResponse.Body != nil {
+		if !IsNil(httpResponse.Body) {
 			var readErr error
 
 			defer httpResponse.Body.Close() // #nosec G307
@@ -533,7 +533,9 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 				return
 			}
 		}
-	} else {
+	} else if !IsNil(httpResponse.Body) {
+		// We weren't expecting a response, but we have a reponse body,
+		// so we need to close it now since we're not going to consume it.
 		_ = httpResponse.Body.Close()
 	}
 

--- a/v5/core/base_service.go
+++ b/v5/core/base_service.go
@@ -533,6 +533,8 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 				return
 			}
 		}
+	} else {
+		_ = httpResponse.Body.Close()
 	}
 
 	return


### PR DESCRIPTION
The method `BaseService.Request` invoked without result (`nil`) does not close `http.Response` and prevents connection to be put back into idle state.

We observed significant memory usage or quick `MaxConnsPerHost` limit exhaustion, when `BaseService.Request` is called with `nil` result.

Issue: https://github.com/IBM/go-sdk-core/issues/175