### PR TITLE
fix(utils): recognize content types with whitespace

### DIFF
--- a/core/utils.go
+++ b/core/utils.go
@@ -39,8 +39,8 @@ func init() {
 }
 
 const (
-	jsonMimePattern      = "(?i)^application\\/((json)|(merge\\-patch\\+json)|(vnd\\..*\\+json))(;.*)?$"
-	jsonPatchMimePattern = "(?i)^application\\/json\\-patch\\+json(;.*)?$"
+	jsonMimePattern      = "(?i)^application\\/((json)|(merge\\-patch\\+json)|(vnd\\..*\\+json))(\\s*;.*)?$"
+	jsonPatchMimePattern = "(?i)^application\\/json\\-patch\\+json(\\s*;.*)?$"
 )
 
 // IsNil checks if the specified object is nil or not.

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -30,6 +30,7 @@ func TestIsJSONMimeType(t *testing.T) {
 	assert.True(t, IsJSONMimeType("application/json"))
 	assert.True(t, IsJSONMimeType("APPlication/json"))
 	assert.True(t, IsJSONMimeType("application/json;blah"))
+	assert.True(t, IsJSONMimeType("application/json ; blah"))
 	assert.True(t, IsJSONMimeType("application/vnd.docker.distribution.manifest.v2+json"))
 	assert.True(t, IsJSONMimeType("application/vnd.anothervendor.custom.semantics+json"))
 	assert.True(t, IsJSONMimeType("application/vnd.yet.another.vendor.with.custom.semantics.blah.v3+json;charset=UTF8"))
@@ -43,6 +44,7 @@ func TestIsJSONPatchMimeType(t *testing.T) {
 	assert.True(t, IsJSONPatchMimeType("application/json-patch+json"))
 	assert.True(t, IsJSONPatchMimeType("APPlication/json-PATCH+json"))
 	assert.True(t, IsJSONPatchMimeType("application/json-patch+json;charset=UTF8"))
+	assert.True(t, IsJSONPatchMimeType("application/json-patch+json ; charset=UTF8"))
 
 	assert.False(t, IsJSONPatchMimeType("application/json"))
 	assert.False(t, IsJSONPatchMimeType("YOapplication/json-patch+jsonYO"))


### PR DESCRIPTION
The RFC for content-type header format allows optional whitespace before the semicolon. Our regular expressions for recognizing various mime types do not account for this, so valid mime types may not be recognized. This commit adjusts the expression to close that gap.