### PR TITLE
build: use `goimports` to format code and check during builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
 install:
   - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.51.2
   - curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+  - go install golang.org/x/tools/cmd/goimports@latest
 
 script:
   - make tidy

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 GO=go
 LINT=golangci-lint
 GOSEC=gosec
+FORMATTER=goimports
 
 COV_OPTS=-coverprofile=coverage.txt -covermode=atomic
 
@@ -15,9 +16,14 @@ test:
 
 lint:
 	${LINT} run --build-tags=all
+	${FORMATTER} -d core
+	if [[ -n `${FORMATTER} -d core` ]]; then exit 1; fi
 
 scan-gosec:
 	${GOSEC} ./...
+
+format:
+	${FORMATTER} -w core
 
 tidy:
 	${GO} mod tidy


### PR DESCRIPTION
This commit adds a new step to the lint step in the builds, which
utilizes the `goimports` tool to check the code style and to report
an error if there is a discrepancy. Furthermore it adds a new `make`
target to automatically format all code in place.