### PR TITLE
build: update build lines and the contributing docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - sudo apt-get update
 
 install:
-  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.51.2
+  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.1
   - curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
   - go install golang.org/x/tools/cmd/goimports@latest
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ If you want to contribute to the repository, here's a quick guide:
      ```
      The above command will run all the unit tests with the command `go test -tags=all`.
      Each unit test file contains one or more build tags as a way to classify the
-     tests into various groups (example: `// +build all fast auth`).
+     tests into various groups (example: `//go:build all || fast || auth`).
      Currently, these tags include: all, slow, fast, auth, basesvc, log and retries.
      Others might be added in the future.
      To run a specific class of tests (example 'retries'), use a command like this:

--- a/core/authenticator_factory_test.go
+++ b/core/authenticator_factory_test.go
@@ -1,5 +1,4 @@
 //go:build all || fast
-// +build all fast
 
 package core
 

--- a/core/base_service_retries_test.go
+++ b/core/base_service_retries_test.go
@@ -1,5 +1,4 @@
 //go:build all || slow || basesvc || retries
-// +build all slow basesvc retries
 
 package core
 

--- a/core/base_service_test.go
+++ b/core/base_service_test.go
@@ -1,5 +1,4 @@
 //go:build all || fast || basesvc
-// +build all fast basesvc
 
 package core
 

--- a/core/basic_authenticator_test.go
+++ b/core/basic_authenticator_test.go
@@ -1,5 +1,4 @@
 //go:build all || fast || auth
-// +build all fast auth
 
 package core
 

--- a/core/bearer_token_authenticator_test.go
+++ b/core/bearer_token_authenticator_test.go
@@ -1,5 +1,4 @@
 //go:build all || fast || auth
-// +build all fast auth
 
 package core
 

--- a/core/common_test.go
+++ b/core/common_test.go
@@ -1,5 +1,4 @@
 //go:build all || fast || basesvc
-// +build all fast basesvc
 
 package core
 

--- a/core/config_utils_test.go
+++ b/core/config_utils_test.go
@@ -1,5 +1,4 @@
 //go:build all || fast || basesvc
-// +build all fast basesvc
 
 package core
 

--- a/core/container_authenticator_test.go
+++ b/core/container_authenticator_test.go
@@ -1,5 +1,4 @@
 //go:build all || auth
-// +build all auth
 
 package core
 

--- a/core/cp4d_authenticator_test.go
+++ b/core/cp4d_authenticator_test.go
@@ -1,5 +1,4 @@
 //go:build all || slow || auth
-// +build all slow auth
 
 package core
 

--- a/core/datetime_test.go
+++ b/core/datetime_test.go
@@ -1,5 +1,4 @@
 //go:build all || fast
-// +build all fast
 
 package core
 

--- a/core/detailed_response_test.go
+++ b/core/detailed_response_test.go
@@ -1,5 +1,4 @@
 //go:build all || fast || basesvc
-// +build all fast basesvc
 
 package core
 

--- a/core/gzip_test.go
+++ b/core/gzip_test.go
@@ -1,5 +1,4 @@
 //go:build all || fast || basesvc
-// +build all fast basesvc
 
 package core
 

--- a/core/iam_authenticator_test.go
+++ b/core/iam_authenticator_test.go
@@ -1,5 +1,4 @@
 //go:build all || slow || auth
-// +build all slow auth
 
 package core
 

--- a/core/jwt_utils_test.go
+++ b/core/jwt_utils_test.go
@@ -1,5 +1,4 @@
 //go:build all || fast || auth
-// +build all fast auth
 
 package core
 

--- a/core/log_test.go
+++ b/core/log_test.go
@@ -1,5 +1,4 @@
 //go:build all || fast || log
-// +build all fast log
 
 package core
 

--- a/core/marshal_nulls_test.go
+++ b/core/marshal_nulls_test.go
@@ -1,5 +1,4 @@
 //go:build all || fast
-// +build all fast
 
 package core
 

--- a/core/mcsp_authenticator_test.go
+++ b/core/mcsp_authenticator_test.go
@@ -1,5 +1,4 @@
 //go:build all || slow || auth
-// +build all slow auth
 
 package core
 

--- a/core/noauth_authenticator_test.go
+++ b/core/noauth_authenticator_test.go
@@ -1,5 +1,4 @@
 //go:build all || fast || auth
-// +build all fast auth
 
 package core
 

--- a/core/parameterized_url_test.go
+++ b/core/parameterized_url_test.go
@@ -1,5 +1,4 @@
 //go:build all || fast
-// +build all fast
 
 package core
 

--- a/core/request_builder_test.go
+++ b/core/request_builder_test.go
@@ -1,5 +1,4 @@
 //go:build all || fast || basesvc
-// +build all fast basesvc
 
 package core
 

--- a/core/unmarshal_v2_models_test.go
+++ b/core/unmarshal_v2_models_test.go
@@ -1,5 +1,4 @@
 //go:build all || fast
-// +build all fast
 
 package core
 

--- a/core/unmarshal_v2_primitives_test.go
+++ b/core/unmarshal_v2_primitives_test.go
@@ -1,5 +1,4 @@
 //go:build all || fast
-// +build all fast
 
 package core
 

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -1,5 +1,4 @@
 //go:build all || fast
-// +build all fast
 
 package core
 

--- a/core/vpc_instance_authenticator_test.go
+++ b/core/vpc_instance_authenticator_test.go
@@ -1,5 +1,4 @@
 //go:build all || auth
-// +build all auth
 
 package core
 


### PR DESCRIPTION
This commit replaces the old Go build tag syntax with
the new one which was released in Go 1.17, since the
current one is deprecated and not used by any tools.
Docs: https://pkg.go.dev/cmd/go#hdr-Build_constraints

Signed-off-by: Norbert Biczo <pyrooka@users.noreply.github.com>