### PR TITLE
build: bump Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: go
 dist: jammy
 
 go:
-- '1.19.x'
 - '1.20.x'
 - '1.21.x'
+- '1.22.x'
 
 notifications:
   email: false
@@ -40,5 +40,5 @@ deploy:
     script: npm run semantic-release
     skip_cleanup: true
     on:
-      go: '1.19.x'
+      go: '1.20.x'
       branch: main

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ go get -u github.com/IBM/go-sdk-core/...
 ```
 
 ## Prerequisites
-- Go version 1.19 or newer
+- Go version 1.20 or newer
 
 ## Authentication
 The go-sdk-core project supports the following types of authentication:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/go-sdk-core/v5
 
-go 1.19
+go 1.20
 
 require (
 	github.com/go-openapi/strfmt v0.22.0


### PR DESCRIPTION
This commit adds the latest Go version to the builds (`1.22`)
and removes the oldest one (`1.19`), so now the minimum
version is `1.20`. 