### PR TITLE
fix(errors): support error checking methods for new problem structures

### DIFF
--- a/core/container_authenticator.go
+++ b/core/container_authenticator.go
@@ -496,8 +496,8 @@ func (authenticator *ContainerAuthenticator) retrieveCRToken() (crToken string, 
 	}
 
 	if err != nil {
-		errMsg := fmt.Sprintf(ERRORMSG_UNABLE_RETRIEVE_CRTOKEN, err.Error())
-		sdkErr := SDKErrorf(nil, errMsg, "no-cr-token", getComponentInfo())
+		err = fmt.Errorf(ERRORMSG_UNABLE_RETRIEVE_CRTOKEN, err.Error())
+		sdkErr := SDKErrorf(err, "", "no-cr-token", getComponentInfo())
 		GetLogger().Debug(sdkErr.GetDebugMessage())
 		err = sdkErr
 		return
@@ -514,8 +514,8 @@ func (authenticator *ContainerAuthenticator) readFile(filename string) (crToken 
 	var bytes []byte
 	bytes, err = os.ReadFile(filename) // #nosec G304
 	if err != nil {
-		err = SDKErrorf(nil, err.Error(), "read-file-error", getComponentInfo())
-		GetLogger().Debug(err.Error())
+		err = SDKErrorf(err, "", "read-file-error", getComponentInfo())
+		GetLogger().Debug(err.(*SDKProblem).GetDebugMessage())
 		return
 	}
 

--- a/core/cp4d_authenticator.go
+++ b/core/cp4d_authenticator.go
@@ -330,7 +330,7 @@ func (authenticator *CloudPakForDataAuthenticator) requestToken() (tokenResponse
 	GetLogger().Debug("Invoking CP4D token service operation: %s", builder.URL)
 	resp, err := authenticator.client().Do(req)
 	if err != nil {
-		err = SDKErrorf(nil, err.Error(), "cp4d-request-error", getComponentInfo())
+		err = SDKErrorf(err, "", "cp4d-request-error", getComponentInfo())
 		return
 	}
 	GetLogger().Debug("Returned from CP4D token service operation, received status code %d", resp.StatusCode)
@@ -369,8 +369,8 @@ func (authenticator *CloudPakForDataAuthenticator) requestToken() (tokenResponse
 	err = json.NewDecoder(resp.Body).Decode(tokenResponse)
 	defer resp.Body.Close() // #nosec G307
 	if err != nil {
-		errMsg := fmt.Sprintf(ERRORMSG_UNMARSHAL_AUTH_RESPONSE, err.Error())
-		err = SDKErrorf(nil, errMsg, "cp4d-res-unmarshal-error", getComponentInfo())
+		err = fmt.Errorf(ERRORMSG_UNMARSHAL_AUTH_RESPONSE, err.Error())
+		err = SDKErrorf(err, "", "cp4d-res-unmarshal-error", getComponentInfo())
 		tokenResponse = nil
 		return
 	}

--- a/core/datetime.go
+++ b/core/datetime.go
@@ -83,7 +83,7 @@ func ParseDate(dateString string) (fmtDate strfmt.Date, err error) {
 	if err == nil {
 		fmtDate = strfmt.Date(formattedTime)
 	} else {
-		err = SDKErrorf(nil, err.Error(), "date-parse-error", getComponentInfo())
+		err = SDKErrorf(err, "", "date-parse-error", getComponentInfo())
 	}
 	return
 }
@@ -93,7 +93,7 @@ func ParseDate(dateString string) (fmtDate strfmt.Date, err error) {
 func ParseDateTime(dateString string) (strfmt.DateTime, error) {
 	dt, err := strfmt.ParseDateTime(dateString)
 	if err != nil {
-		err = SDKErrorf(nil, err.Error(), "datetime-parse-error", getComponentInfo())
+		err = SDKErrorf(err, "", "datetime-parse-error", getComponentInfo())
 	}
 	return dt, err
 }

--- a/core/file_with_metadata.go
+++ b/core/file_with_metadata.go
@@ -58,7 +58,7 @@ func UnmarshalFileWithMetadata(m map[string]json.RawMessage, result interface{})
 	}
 	data, err = os.Open(pathToData) // #nosec G304
 	if err != nil {
-		err = SDKErrorf(nil, err.Error(), "file-open-error", getComponentInfo())
+		err = SDKErrorf(err, "", "file-open-error", getComponentInfo())
 		return
 	}
 	obj.Data = data

--- a/core/gzip.go
+++ b/core/gzip.go
@@ -42,7 +42,7 @@ func NewGzipCompressionReader(uncompressedReader io.Reader) (io.Reader, error) {
 		// to the pipe only when the pipe reader is called to retrieve more bytes.
 		_, err := io.Copy(compressedWriter, uncompressedReader)
 		if err != nil {
-			sdkErr := SDKErrorf(nil, err.Error(), "compression-failed", getComponentInfo())
+			sdkErr := SDKErrorf(err, "", "compression-failed", getComponentInfo())
 			_ = pipeWriter.CloseWithError(sdkErr)
 		}
 	}()
@@ -54,7 +54,7 @@ func NewGzipCompressionReader(uncompressedReader io.Reader) (io.Reader, error) {
 func NewGzipDecompressionReader(compressedReader io.Reader) (io.Reader, error) {
 	res, err := gzip.NewReader(compressedReader)
 	if err != nil {
-		err = SDKErrorf(nil, err.Error(), "decompress-read-error", getComponentInfo())
+		err = SDKErrorf(err, "", "decompress-read-error", getComponentInfo())
 	}
 	return res, err
 }

--- a/core/http_problem.go
+++ b/core/http_problem.go
@@ -57,6 +57,13 @@ func (e *HTTPProblem) GetID() string {
 	return CreateIDHash("http", e.GetBaseSignature(), e.OperationID, fmt.Sprint(e.Response.GetStatusCode()))
 }
 
+// Is allows an HTTPProblem instance to be compared against another error for equality.
+// An HTTPProblem is considered equal to another error if 1) the error is also a Problem and
+// 2) it has the same ID (i.e. it is the same problem scenario).
+func (e *HTTPProblem) Is(target error) bool {
+	return is(target, e.GetID())
+}
+
 func (e *HTTPProblem) getErrorCode() string {
 	// If the error response was a standard JSON body, the result will
 	// be a map and we can do a decent job of guessing the code.

--- a/core/http_problem_test.go
+++ b/core/http_problem_test.go
@@ -15,6 +15,7 @@ package core
 // limitations under the License.
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 
@@ -218,6 +219,17 @@ func TestHTTPProblemGetErrorCodeEmpty(t *testing.T) {
 func TestHTTPProblemGetErrorCode(t *testing.T) {
 	httpProb := httpErrorf("Bad request", getPopulatedDetailedResponse())
 	assert.Equal(t, "invalid-input", httpProb.getErrorCode())
+}
+
+func TestHTTPProblemIsWithProblem(t *testing.T) {
+	firstProb := httpErrorf("Bad request", getPopulatedDetailedResponse())
+	EnrichHTTPProblem(firstProb, "create_resource", NewProblemComponent("service", "1.0.0"))
+
+	secondProb := httpErrorf("Invalid input", getPopulatedDetailedResponse())
+	EnrichHTTPProblem(secondProb, "create_resource", NewProblemComponent("service", "1.2.3"))
+
+	assert.NotEqual(t, firstProb, secondProb)
+	assert.True(t, errors.Is(firstProb, secondProb))
 }
 
 func TestHTTPErrorf(t *testing.T) {

--- a/core/iam_authenticator.go
+++ b/core/iam_authenticator.go
@@ -463,7 +463,7 @@ func (authenticator *IamAuthenticator) RequestToken() (*IamTokenServerResponse, 
 	GetLogger().Debug("Invoking IAM 'get token' operation: %s", builder.URL)
 	resp, err := authenticator.client().Do(req)
 	if err != nil {
-		err = SDKErrorf(nil, err.Error(), "request-error", getComponentInfo())
+		err = SDKErrorf(err, "", "request-error", getComponentInfo())
 		return nil, err
 	}
 	GetLogger().Debug("Returned from IAM 'get token' operation, received status code %d", resp.StatusCode)

--- a/core/jwt_utils.go
+++ b/core/jwt_utils.go
@@ -47,7 +47,8 @@ func parseJWT(tokenString string) (claims *coreJWTClaims, err error) {
 	claims = &coreJWTClaims{}
 	err = json.Unmarshal(claimBytes, claims)
 	if err != nil {
-		err = SDKErrorf(nil, fmt.Sprintf("error unmarshalling token: %s", err.Error()), "bad-token", getComponentInfo())
+		err = fmt.Errorf("error unmarshalling token: %s", err.Error())
+		err = SDKErrorf(err, "", "bad-token", getComponentInfo())
 		return
 	}
 
@@ -63,7 +64,7 @@ func decodeSegment(seg string) ([]byte, error) {
 
 	res, err := base64.URLEncoding.DecodeString(seg)
 	if err != nil {
-		err = SDKErrorf(nil, fmt.Sprintf("error decoding claims segment: %s", err.Error()), "bad-claim-seg", getComponentInfo())
+		err = SDKErrorf(err, fmt.Sprintf("error decoding claims segment: %s", err.Error()), "bad-claim-seg", getComponentInfo())
 	}
 	return res, err
 }

--- a/core/mcsp_authenticator.go
+++ b/core/mcsp_authenticator.go
@@ -304,7 +304,7 @@ func (authenticator *MCSPAuthenticator) RequestToken() (*MCSPTokenServerResponse
 	GetLogger().Debug("Invoking MCSP 'get token' operation: %s", builder.URL)
 	resp, err := authenticator.client().Do(req)
 	if err != nil {
-		err = SDKErrorf(nil, err.Error(), "request-error", getComponentInfo())
+		err = SDKErrorf(err, "", "request-error", getComponentInfo())
 		return nil, err
 	}
 	GetLogger().Debug("Returned from MCSP 'get token' operation, received status code %d", resp.StatusCode)

--- a/core/problem_utils.go
+++ b/core/problem_utils.go
@@ -17,6 +17,7 @@ package core
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -54,4 +55,13 @@ func getProblemInfoAsYAML(orderedMaps *OrderedMaps) string {
 // component alongside the current semantic version of the component.
 func getComponentInfo() *ProblemComponent {
 	return NewProblemComponent(MODULE_NAME, __VERSION__)
+}
+
+// is provides a simple utility function that assists problem types
+// implement an "Is" function for checking error equality. Error types
+// are treated as equivalent if they are both Problem types and their
+// IDs match.
+func is(target error, id string) bool {
+	var problem Problem
+	return errors.As(target, &problem) && problem.GetID() == id
 }

--- a/core/sdk_problem.go
+++ b/core/sdk_problem.go
@@ -55,6 +55,13 @@ func (e *SDKProblem) GetID() string {
 	return CreateIDHash("sdk", e.GetBaseSignature(), e.Function)
 }
 
+// Is allows an SDKProblem instance to be compared against another error for equality.
+// An SDKProblem is considered equal to another error if 1) the error is also a Problem and
+// 2) it has the same ID (i.e. it is the same problem scenario).
+func (e *SDKProblem) Is(target error) bool {
+	return is(target, e.GetID())
+}
+
 // GetConsoleOrderedMaps returns an ordered-map representation
 // of an SDKProblem instance suited for a console message.
 func (e *SDKProblem) GetConsoleOrderedMaps() *OrderedMaps {

--- a/core/sdk_problem_test.go
+++ b/core/sdk_problem_test.go
@@ -15,6 +15,8 @@ package core
 // limitations under the License.
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -168,7 +170,7 @@ func TestSDKErrorf(t *testing.T) {
 	assert.Equal(t, "github.com/IBM/go-sdk-core/v5/core.TestSDKErrorf", stack[0].Function)
 	assert.Contains(t, stack[0].File, "core/sdk_problem_test.go")
 	// This might be too fragile. If it becomes an issue, we can remove it.
-	assert.Equal(t, 156, stack[0].Line)
+	assert.Equal(t, 158, stack[0].Line)
 }
 
 func TestSDKErrorfNoCausedBy(t *testing.T) {
@@ -237,6 +239,19 @@ func TestRepurposeSDKProblemNonSDKProblem(t *testing.T) {
 	mockProb := mockProblem{}
 	err := RepurposeSDKProblem(mockProb, "new-disc")
 	assert.Equal(t, mockProb, err)
+}
+
+func TestSDKProblemIsWithProblem(t *testing.T) {
+	firstProb := SDKErrorf(nil, "Some error", "disc", getComponentInfo())
+	secondProb := SDKErrorf(nil, "Same error, different message", "disc", getComponentInfo())
+	assert.NotEqual(t, firstProb, secondProb)
+	assert.True(t, errors.Is(firstProb, secondProb))
+}
+
+func TestSDKProblemIsWithNative(t *testing.T) {
+	firstProb := SDKErrorf(context.Canceled, "Some error", "disc", getComponentInfo())
+	secondProb := SDKErrorf(firstProb, "Wrapping error", "disc", getComponentInfo())
+	assert.True(t, errors.Is(secondProb, context.Canceled))
 }
 
 func getPopulatedSDKProblem() *SDKProblem {

--- a/core/unmarshal_v2.go
+++ b/core/unmarshal_v2.go
@@ -85,8 +85,8 @@ func UnmarshalPrimitive(rawInput map[string]json.RawMessage, propertyName string
 	if foundIt && rawMsg != nil {
 		err = json.Unmarshal(rawMsg, result)
 		if err != nil {
-			errMsg := fmt.Sprintf(errorUnmarshalPrimitive, propertyName, err.Error())
-			err = SDKErrorf(nil, errMsg, "json-unmarshal-error", getComponentInfo())
+			err = fmt.Errorf(errorUnmarshalPrimitive, propertyName, err.Error())
+			err = SDKErrorf(err, "", "json-unmarshal-error", getComponentInfo())
 		}
 	}
 	return
@@ -290,8 +290,8 @@ func unmarshalModelInstance(rawInput interface{}, propertyName string, result in
 	// Obtain the unmarshal input source from 'rawInput'.
 	foundInput, rawMap, err = getUnmarshalInputSourceMap(rawInput, propertyName)
 	if err != nil {
-		errMsg := fmt.Sprintf(errorUnmarshalModel, propInsert(propertyName), getModelResultType(result), err.Error())
-		err = SDKErrorf(nil, errMsg, "input-source-error", getComponentInfo())
+		err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName), getModelResultType(result), err.Error())
+		err = SDKErrorf(err, "", "input-source-error", getComponentInfo())
 		return
 	}
 
@@ -308,8 +308,8 @@ func unmarshalModelInstance(rawInput interface{}, propertyName string, result in
 	if foundInput && rawMap != nil {
 		err = unmarshaller(rawMap, result)
 		if err != nil {
-			errMsg := fmt.Sprintf(errorUnmarshalModel, propInsert(propertyName), getModelResultType(result), err.Error())
-			err = SDKErrorf(nil, errMsg, "unmarshaller-error", getComponentInfo())
+			err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName), getModelResultType(result), err.Error())
+			err = SDKErrorf(err, "", "unmarshaller-error", getComponentInfo())
 			return
 		}
 	}
@@ -345,9 +345,9 @@ func unmarshalModelSlice(rawInput interface{}, propertyName string, result inter
 	// Obtain the unmarshal input source from 'rawInput'.
 	foundInput, rawSlice, err = getUnmarshalInputSourceSlice(rawInput, propertyName)
 	if err != nil {
-		errMsg := fmt.Sprintf(errorUnmarshalModel, propInsert(propertyName),
+		err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
 			reflect.TypeOf(result).Elem().String(), err.Error())
-		err = SDKErrorf(nil, errMsg, "input-source-error", getComponentInfo())
+		err = SDKErrorf(err, "", "input-source-error", getComponentInfo())
 		return
 	}
 
@@ -373,9 +373,9 @@ func unmarshalModelSlice(rawInput interface{}, propertyName string, result inter
 		var receiverType reflect.Type
 		receiverType, err = getUnmarshalResultType(result)
 		if err != nil {
-			errMsg := fmt.Sprintf(errorUnmarshalModel, propInsert(propertyName),
+			err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
 				reflect.TypeOf(result).Elem().String(), err.Error())
-			err = SDKErrorf(nil, errMsg, "result-type-error", getComponentInfo())
+			err = SDKErrorf(err, "", "result-type-error", getComponentInfo())
 			return
 		}
 
@@ -384,9 +384,9 @@ func unmarshalModelSlice(rawInput interface{}, propertyName string, result inter
 			rawMap := make(map[string]json.RawMessage)
 			err = json.Unmarshal(rawMsg, &rawMap)
 			if err != nil {
-				errMsg := fmt.Sprintf(errorUnmarshalModel, propInsert(propertyName),
+				err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
 					reflect.TypeOf(result).Elem().String(), err.Error())
-				err = SDKErrorf(nil, errMsg, "json-unmarshal-error", getComponentInfo())
+				err = SDKErrorf(err, "", "json-unmarshal-error", getComponentInfo())
 				return
 			}
 
@@ -396,9 +396,9 @@ func unmarshalModelSlice(rawInput interface{}, propertyName string, result inter
 			// Invoke the model-specific unmarshaller.
 			err = unmarshaller(rawMap, rModelReceiver.Interface())
 			if err != nil {
-				errMsg := fmt.Sprintf(errorUnmarshalModel, propInsert(propertyName),
+				err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
 					reflect.TypeOf(result).Elem().String(), err.Error())
-				err = SDKErrorf(nil, errMsg, "unmarshaller-error", getComponentInfo())
+				err = SDKErrorf(err, "", "unmarshaller-error", getComponentInfo())
 				return
 			}
 
@@ -438,9 +438,9 @@ func unmarshalModelSliceSlice(rawInput interface{}, propertyName string, result 
 	// Obtain the unmarshal input source from 'rawInput'.
 	foundInput, rawSlice, err = getUnmarshalInputSourceSlice(rawInput, propertyName)
 	if err != nil {
-		errMsg := fmt.Sprintf(errorUnmarshalModel, propInsert(propertyName),
+		err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
 			reflect.TypeOf(result).Elem().String(), err.Error())
-		err = SDKErrorf(nil, errMsg, "input-source-error", getComponentInfo())
+		err = SDKErrorf(err, "", "input-source-error", getComponentInfo())
 		return
 	}
 
@@ -469,9 +469,9 @@ func unmarshalModelSliceSlice(rawInput interface{}, propertyName string, result 
 			var innerRawSlice []json.RawMessage
 			err = json.Unmarshal(rawMsg, &innerRawSlice)
 			if err != nil {
-				errMsg := fmt.Sprintf(errorUnmarshalModel, propInsert(propertyName),
+				err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
 					reflect.TypeOf(result).Elem().String(), err.Error())
-				err = SDKErrorf(nil, errMsg, "json-unmarshal-error", getComponentInfo())
+				err = SDKErrorf(err, "", "json-unmarshal-error", getComponentInfo())
 				return
 			}
 
@@ -481,9 +481,9 @@ func unmarshalModelSliceSlice(rawInput interface{}, propertyName string, result 
 			// Unmarshal 'innerRawSlice' into a slice of models.
 			err = unmarshalModelSlice(innerRawSlice, "", rSliceValue.Interface(), unmarshaller)
 			if err != nil {
-				errMsg := fmt.Sprintf(errorUnmarshalModel, propInsert(propertyName),
+				err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
 					reflect.TypeOf(result).Elem().String(), err.Error())
-				err = SDKErrorf(nil, errMsg, "unmarshaller-error", getComponentInfo())
+				err = SDKErrorf(err, "", "unmarshaller-error", getComponentInfo())
 				return
 			}
 
@@ -516,9 +516,9 @@ func unmarshalModelMap(rawInput interface{}, propertyName string, result interfa
 	// Obtain the unmarshal input source from 'rawInput'.
 	foundInput, rawMap, err = getUnmarshalInputSourceMap(rawInput, propertyName)
 	if err != nil {
-		errMsg := fmt.Sprintf(errorUnmarshalModel, propInsert(propertyName),
+		err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
 			reflect.TypeOf(result).Elem().String(), err.Error())
-		err = SDKErrorf(nil, errMsg, "input-source-error", getComponentInfo())
+		err = SDKErrorf(err, "", "input-source-error", getComponentInfo())
 		return
 	}
 
@@ -537,9 +537,9 @@ func unmarshalModelMap(rawInput interface{}, propertyName string, result interfa
 		var receiverType reflect.Type
 		receiverType, err = getUnmarshalResultType(result)
 		if err != nil {
-			errMsg := fmt.Sprintf(errorUnmarshalModel, propInsert(propertyName),
+			err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
 				reflect.TypeOf(result).Elem().String(), err.Error())
-			err = SDKErrorf(nil, errMsg, "result-type-error", getComponentInfo())
+			err = SDKErrorf(err, "", "result-type-error", getComponentInfo())
 			return
 		}
 
@@ -549,9 +549,9 @@ func unmarshalModelMap(rawInput interface{}, propertyName string, result interfa
 			modelInstanceMap := make(map[string]json.RawMessage)
 			err = json.Unmarshal(v, &modelInstanceMap)
 			if err != nil {
-				errMsg := fmt.Sprintf(errorUnmarshalModel, propInsert(propertyName),
+				err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
 					reflect.TypeOf(result).Elem().String(), err.Error())
-				err = SDKErrorf(nil, errMsg, "json-unmarshal-error", getComponentInfo())
+				err = SDKErrorf(err, "", "json-unmarshal-error", getComponentInfo())
 				return
 			}
 
@@ -561,9 +561,9 @@ func unmarshalModelMap(rawInput interface{}, propertyName string, result interfa
 			// Unmarshal the model instance contained in 'modelInstanceMap'.
 			err = unmarshaller(modelInstanceMap, rModelReceiver.Interface())
 			if err != nil {
-				errMsg := fmt.Sprintf(errorUnmarshalModel, propInsert(propertyName),
+				err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
 					reflect.TypeOf(result).Elem().String(), err.Error())
-				err = SDKErrorf(nil, errMsg, "unmarshaller-error", getComponentInfo())
+				err = SDKErrorf(err, "", "unmarshaller-error", getComponentInfo())
 				return
 			}
 
@@ -597,9 +597,9 @@ func unmarshalModelSliceMap(rawInput interface{}, propertyName string, result in
 	// Obtain the unmarshal input source from 'rawInput'.
 	foundInput, rawMap, err = getUnmarshalInputSourceMap(rawInput, propertyName)
 	if err != nil {
-		errMsg := fmt.Sprintf(errorUnmarshalModel, propInsert(propertyName),
+		err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
 			reflect.TypeOf(result).Elem().String(), err.Error())
-		err = SDKErrorf(nil, errMsg, "input-source-error", getComponentInfo())
+		err = SDKErrorf(err, "", "input-source-error", getComponentInfo())
 		return
 	}
 
@@ -622,9 +622,9 @@ func unmarshalModelSliceMap(rawInput interface{}, propertyName string, result in
 				var rawSlice []json.RawMessage
 				err = json.Unmarshal(v, &rawSlice)
 				if err != nil {
-					errMsg := fmt.Sprintf(errorUnmarshalModel, propInsert(propertyName),
+					err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
 						reflect.TypeOf(result).Elem().String(), err.Error())
-					err = SDKErrorf(nil, errMsg, "json-unmarshal-error", getComponentInfo())
+					err = SDKErrorf(err, "", "json-unmarshal-error", getComponentInfo())
 					return
 				}
 
@@ -634,9 +634,9 @@ func unmarshalModelSliceMap(rawInput interface{}, propertyName string, result in
 				// Unmarshal rawSlice into a model slice.
 				err = unmarshalModelSlice(rawSlice, "", rSliceValue.Interface(), unmarshaller)
 				if err != nil {
-					errMsg := fmt.Sprintf(errorUnmarshalModel, propInsert(propertyName),
+					err = fmt.Errorf(errorUnmarshalModel, propInsert(propertyName),
 						reflect.TypeOf(result).Elem().String(), err.Error())
-					err = SDKErrorf(nil, errMsg, "unmarshaller-error", getComponentInfo())
+					err = SDKErrorf(err, "", "unmarshaller-error", getComponentInfo())
 					return
 				}
 
@@ -680,7 +680,7 @@ func getUnmarshalInputSourceMap(rawInput interface{}, propertyName string) (foun
 			err = json.Unmarshal(rawMsg, &rawMap)
 			if err != nil {
 				foundInput = false
-				err = SDKErrorf(nil, err.Error(), "json-unmarshal-error", getComponentInfo())
+				err = SDKErrorf(err, "", "json-unmarshal-error", getComponentInfo())
 				return
 			}
 		}
@@ -723,8 +723,8 @@ func getUnmarshalInputSourceSlice(rawInput interface{}, propertyName string) (fo
 			var rawSlice = make([]json.RawMessage, 0)
 			err = json.Unmarshal(rawMsg, &rawSlice)
 			if err != nil {
-				errMsg := fmt.Sprintf(errorIncorrectInputType, "map[string][]json.RawMessage", reflect.TypeOf(rawInput).String())
-				err = SDKErrorf(nil, errMsg, "json-unmarshal-error", getComponentInfo())
+				err = fmt.Errorf(errorIncorrectInputType, "map[string][]json.RawMessage", reflect.TypeOf(rawInput).String())
+				err = SDKErrorf(err, "", "json-unmarshal-error", getComponentInfo())
 				return
 			}
 

--- a/core/utils.go
+++ b/core/utils.go
@@ -77,11 +77,10 @@ func ValidateStruct(param interface{}, paramName string) error {
 	if err != nil {
 		// If there were validation errors then return an error containing the field errors
 		if fieldErrors, ok := err.(validator.ValidationErrors); ok {
-			errMsg := fmt.Sprintf("%s failed validation:\n%s", paramName, fieldErrors.Error())
-			err = SDKErrorf(nil, errMsg, "struct-validation-errors", getComponentInfo())
+			err = fmt.Errorf("%s failed validation:\n%s", paramName, fieldErrors.Error())
+			return SDKErrorf(err, "", "struct-validation-errors", getComponentInfo())
 		}
-		errMsg := fmt.Sprintf("Failed to validate %s:\n%s", paramName, err.Error())
-		return SDKErrorf(nil, errMsg, "struct-validate-unknown-error", getComponentInfo())
+		return SDKErrorf(err, "", "struct-validate-unknown-error", getComponentInfo())
 	}
 
 	return nil
@@ -231,8 +230,8 @@ func ConvertSlice(slice interface{}) (s []string, err error) {
 
 	jsonBuffer, err := json.Marshal(slice)
 	if err != nil {
-		errMsg := fmt.Sprintf(ERRORMSG_MARSHAL_SLICE, err.Error())
-		err = SDKErrorf(nil, errMsg, "slice-marshal-error", getComponentInfo())
+		err = fmt.Errorf(ERRORMSG_MARSHAL_SLICE, err.Error())
+		err = SDKErrorf(err, "", "slice-marshal-error", getComponentInfo())
 		return
 	}
 
@@ -281,17 +280,15 @@ func GetQueryParam(urlStr *string, param string) (value *string, err error) {
 		return
 	}
 
-	errMsgTempl := "Could not read query param %s from URL:\n%s"
-
 	urlObj, err := url.Parse(*urlStr)
 	if err != nil {
-		err = SDKErrorf(nil, fmt.Sprintf(errMsgTempl, param, err.Error()), "url-parse-error", getComponentInfo())
+		err = SDKErrorf(err, "", "url-parse-error", getComponentInfo())
 		return
 	}
 
 	query, err := url.ParseQuery(urlObj.RawQuery)
 	if err != nil {
-		err = SDKErrorf(nil, fmt.Sprintf(errMsgTempl, param, err.Error()), "url-parse-query-error", getComponentInfo())
+		err = SDKErrorf(err, "", "url-parse-query-error", getComponentInfo())
 		return
 	}
 
@@ -320,8 +317,7 @@ func GetQueryParamAsInt(urlStr *string, param string) (value *int64, err error) 
 
 	intValue, err := strconv.ParseInt(*strValue, 10, 64)
 	if err != nil {
-		errMsg := fmt.Sprintf("Could not read query param %s as an int:\n%s", param, err.Error())
-		err = SDKErrorf(nil, errMsg, "parse-int-query-error", getComponentInfo())
+		err = SDKErrorf(err, "", "parse-int-query-error", getComponentInfo())
 		return nil, err
 	}
 


### PR DESCRIPTION
Adds previously returned errors to the "Unwrap" chain for checking against in methods like "errors.Is()" and adds an implementation of "Is" to Problem types to enable equality checking against problems.

Also, adds all of the previously returned errors back into the problem structures to maintain full compatibility with downstream code.