### PR TITLE
fix(errors): restore matching against all original errors

### DIFF
--- a/core/base_service.go
+++ b/core/base_service.go
@@ -85,11 +85,13 @@ type BaseService struct {
 // parameters and service options will be performed before instance creation.
 func NewBaseService(options *ServiceOptions) (*BaseService, error) {
 	if HasBadFirstOrLastChar(options.URL) {
-		return nil, SDKErrorf(nil, fmt.Sprintf(ERRORMSG_PROP_INVALID, "URL"), "bad-char", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_PROP_INVALID, "URL")
+		return nil, SDKErrorf(err, "", "bad-char", getComponentInfo())
 	}
 
 	if IsNil(options.Authenticator) {
-		return nil, SDKErrorf(nil, ERRORMSG_NO_AUTHENTICATOR, "missing-auth", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_NO_AUTHENTICATOR)
+		return nil, SDKErrorf(err, "", "missing-auth", getComponentInfo())
 	}
 
 	if err := options.Authenticator.Validate(); err != nil {
@@ -214,7 +216,8 @@ func (service *BaseService) SetURL(url string) error {
 // SetServiceURL sets the service URL.
 func (service *BaseService) SetServiceURL(url string) error {
 	if HasBadFirstOrLastChar(url) {
-		return SDKErrorf(nil, fmt.Sprintf(ERRORMSG_PROP_INVALID, "URL"), "bad-char", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_PROP_INVALID, "URL")
+		return SDKErrorf(err, "", "bad-char", getComponentInfo())
 	}
 
 	service.Options.URL = url
@@ -375,7 +378,8 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 
 	// Add authentication to the outbound request.
 	if IsNil(service.Options.Authenticator) {
-		err = SDKErrorf(nil, ERRORMSG_NO_AUTHENTICATOR, "missing-auth", getComponentInfo())
+		err = fmt.Errorf(ERRORMSG_NO_AUTHENTICATOR)
+		err = SDKErrorf(err, "", "missing-auth", getComponentInfo())
 		return
 	}
 

--- a/core/basic_authenticator.go
+++ b/core/basic_authenticator.go
@@ -47,7 +47,8 @@ func NewBasicAuthenticator(username string, password string) (*BasicAuthenticato
 // from a map.
 func newBasicAuthenticatorFromMap(properties map[string]string) (*BasicAuthenticator, error) {
 	if properties == nil {
-		return nil, SDKErrorf(nil, ERRORMSG_PROPS_MAP_NIL, "missing-props", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_PROPS_MAP_NIL)
+		return nil, SDKErrorf(err, "", "missing-props", getComponentInfo())
 	}
 
 	return NewBasicAuthenticator(properties[PROPNAME_USERNAME], properties[PROPNAME_PASSWORD])
@@ -74,19 +75,23 @@ func (this *BasicAuthenticator) Authenticate(request *http.Request) error {
 // they do not contain invalid characters.
 func (this BasicAuthenticator) Validate() error {
 	if this.Username == "" {
-		return SDKErrorf(nil, fmt.Sprintf(ERRORMSG_PROP_MISSING, "Username"), "no-user", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_PROP_MISSING, "Username")
+		return SDKErrorf(err, "", "no-user", getComponentInfo())
 	}
 
 	if this.Password == "" {
-		return SDKErrorf(nil, fmt.Sprintf(ERRORMSG_PROP_MISSING, "Password"), "no-pass", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_PROP_MISSING, "Password")
+		return SDKErrorf(err, "", "no-pass", getComponentInfo())
 	}
 
 	if HasBadFirstOrLastChar(this.Username) {
-		return SDKErrorf(nil, fmt.Sprintf(ERRORMSG_PROP_INVALID, "Username"), "bad-user", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_PROP_INVALID, "Username")
+		return SDKErrorf(err, "", "bad-user", getComponentInfo())
 	}
 
 	if HasBadFirstOrLastChar(this.Password) {
-		return SDKErrorf(nil, fmt.Sprintf(ERRORMSG_PROP_INVALID, "Password"), "bad-pass", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_PROP_INVALID, "Password")
+		return SDKErrorf(err, "", "bad-pass", getComponentInfo())
 	}
 
 	return nil

--- a/core/bearer_token_authenticator.go
+++ b/core/bearer_token_authenticator.go
@@ -44,7 +44,8 @@ func NewBearerTokenAuthenticator(bearerToken string) (*BearerTokenAuthenticator,
 // newBearerTokenAuthenticator : Constructs a new BearerTokenAuthenticator instance from a map.
 func newBearerTokenAuthenticatorFromMap(properties map[string]string) (*BearerTokenAuthenticator, error) {
 	if properties == nil {
-		return nil, SDKErrorf(nil, ERRORMSG_PROPS_MAP_NIL, "missing-props", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_PROPS_MAP_NIL)
+		return nil, SDKErrorf(err, "", "missing-props", getComponentInfo())
 	}
 
 	return NewBearerTokenAuthenticator(properties[PROPNAME_BEARER_TOKEN])
@@ -70,7 +71,8 @@ func (this *BearerTokenAuthenticator) Authenticate(request *http.Request) error 
 // Ensures the bearer token is not Nil.
 func (this BearerTokenAuthenticator) Validate() error {
 	if this.BearerToken == "" {
-		return SDKErrorf(nil, fmt.Sprintf(ERRORMSG_PROP_MISSING, "BearerToken"), "no-token", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_PROP_MISSING, "BearerToken")
+		return SDKErrorf(err, "", "no-token", getComponentInfo())
 	}
 	return nil
 }

--- a/core/config_utils.go
+++ b/core/config_utils.go
@@ -17,6 +17,7 @@ package core
 import (
 	"bufio"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -57,7 +58,8 @@ func GetServiceProperties(serviceName string) (serviceProps map[string]string, e
 func getServiceProperties(serviceName string) (serviceProps map[string]string, err error) {
 
 	if serviceName == "" {
-		err = SDKErrorf(nil, "serviceName was not specified", "no-service-name", getComponentInfo())
+		err = fmt.Errorf("serviceName was not specified")
+		err = SDKErrorf(err, "", "no-service-name", getComponentInfo())
 		return
 	}
 

--- a/core/container_authenticator.go
+++ b/core/container_authenticator.go
@@ -203,7 +203,8 @@ func (authenticator *ContainerAuthenticator) client() *http.Client {
 // configuration properties.
 func newContainerAuthenticatorFromMap(properties map[string]string) (authenticator *ContainerAuthenticator, err error) {
 	if properties == nil {
-		return nil, SDKErrorf(nil, ERRORMSG_PROPS_MAP_NIL, "missing-props", getComponentInfo())
+		err = fmt.Errorf(ERRORMSG_PROPS_MAP_NIL)
+		return nil, SDKErrorf(err, "", "missing-props", getComponentInfo())
 	}
 
 	// Grab the AUTH_DISABLE_SSL string property and convert to a boolean value.
@@ -283,8 +284,8 @@ func (authenticator *ContainerAuthenticator) Validate() error {
 
 	// Check to make sure that one of IAMProfileName or IAMProfileID are specified.
 	if authenticator.IAMProfileName == "" && authenticator.IAMProfileID == "" {
-		errMsg := fmt.Sprintf(ERRORMSG_ATLEAST_ONE_PROP_ERROR, "IAMProfileName", "IAMProfileID")
-		return SDKErrorf(nil, errMsg, "both-props", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_ATLEAST_ONE_PROP_ERROR, "IAMProfileName", "IAMProfileID")
+		return SDKErrorf(err, "", "both-props", getComponentInfo())
 	}
 
 	// Validate ClientId and ClientSecret.  They must both be specified togther or neither should be specified.
@@ -293,13 +294,13 @@ func (authenticator *ContainerAuthenticator) Validate() error {
 	} else {
 		// Since it is NOT the case that both properties are empty, make sure BOTH are specified.
 		if authenticator.ClientID == "" {
-			errMsg := fmt.Sprintf(ERRORMSG_PROP_MISSING, "ClientID")
-			return SDKErrorf(nil, errMsg, "missing-id", getComponentInfo())
+			err := fmt.Errorf(ERRORMSG_PROP_MISSING, "ClientID")
+			return SDKErrorf(err, "", "missing-id", getComponentInfo())
 		}
 
 		if authenticator.ClientSecret == "" {
-			errMsg := fmt.Sprintf(ERRORMSG_PROP_MISSING, "ClientSecret")
-			return SDKErrorf(nil, errMsg, "missing-secret", getComponentInfo())
+			err := fmt.Errorf(ERRORMSG_PROP_MISSING, "ClientSecret")
+			return SDKErrorf(err, "", "missing-secret", getComponentInfo())
 		}
 	}
 
@@ -328,7 +329,8 @@ func (authenticator *ContainerAuthenticator) GetToken() (string, error) {
 
 	// return an error if the access token is not valid or was not fetched
 	if authenticator.getTokenData() == nil || authenticator.getTokenData().AccessToken == "" {
-		return "", SDKErrorf(nil, "Error while trying to get access token", "no-token", getComponentInfo())
+		err := fmt.Errorf("Error while trying to get access token")
+		return "", SDKErrorf(err, "", "no-token", getComponentInfo())
 	}
 
 	return authenticator.getTokenData().AccessToken, nil

--- a/core/cp4d_authenticator.go
+++ b/core/cp4d_authenticator.go
@@ -117,7 +117,8 @@ func newAuthenticator(url string, username string, password string, apikey strin
 // newCloudPakForDataAuthenticatorFromMap : Constructs a new CloudPakForDataAuthenticator instance from a map.
 func newCloudPakForDataAuthenticatorFromMap(properties map[string]string) (*CloudPakForDataAuthenticator, error) {
 	if properties == nil {
-		return nil, SDKErrorf(nil, ERRORMSG_PROPS_MAP_NIL, "missing-props", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_PROPS_MAP_NIL)
+		return nil, SDKErrorf(err, "", "missing-props", getComponentInfo())
 	}
 
 	disableSSL, err := strconv.ParseBool(properties[PROPNAME_AUTH_DISABLE_SSL])
@@ -142,20 +143,20 @@ func (*CloudPakForDataAuthenticator) AuthenticationType() string {
 func (authenticator *CloudPakForDataAuthenticator) Validate() error {
 
 	if authenticator.Username == "" {
-		errMsg := fmt.Sprintf(ERRORMSG_PROP_MISSING, "Username")
-		return SDKErrorf(nil, errMsg, "no-user", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_PROP_MISSING, "Username")
+		return SDKErrorf(err, "", "no-user", getComponentInfo())
 	}
 
 	// The user should specify exactly one of APIKey or Password.
 	if (authenticator.APIKey == "" && authenticator.Password == "") ||
 		(authenticator.APIKey != "" && authenticator.Password != "") {
-		errMsg := fmt.Sprintf(ERRORMSG_EXCLUSIVE_PROPS_ERROR, "APIKey", "Password")
-		return SDKErrorf(nil, errMsg, "exc-props", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_EXCLUSIVE_PROPS_ERROR, "APIKey", "Password")
+		return SDKErrorf(err, "", "exc-props", getComponentInfo())
 	}
 
 	if authenticator.URL == "" {
-		errMsg := fmt.Sprintf(ERRORMSG_PROP_MISSING, "URL")
-		return SDKErrorf(nil, errMsg, "no-url", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_PROP_MISSING, "URL")
+		return SDKErrorf(err, "", "no-url", getComponentInfo())
 	}
 
 	return nil
@@ -231,7 +232,8 @@ func (authenticator *CloudPakForDataAuthenticator) GetToken() (string, error) {
 
 	// return an error if the access token is not valid or was not fetched
 	if authenticator.getTokenData() == nil || authenticator.getTokenData().AccessToken == "" {
-		return "", SDKErrorf(nil, "Error while trying to get access token", "no-token", getComponentInfo())
+		err := fmt.Errorf("Error while trying to get access token")
+		return "", SDKErrorf(err, "", "no-token", getComponentInfo())
 	}
 
 	return authenticator.getTokenData().AccessToken, nil

--- a/core/iam_authenticator.go
+++ b/core/iam_authenticator.go
@@ -209,7 +209,8 @@ func NewIamAuthenticator(apiKey string, url string, clientId string, clientSecre
 // newIamAuthenticatorFromMap constructs a new IamAuthenticator instance from a map.
 func newIamAuthenticatorFromMap(properties map[string]string) (authenticator *IamAuthenticator, err error) {
 	if properties == nil {
-		return nil, SDKErrorf(nil, ERRORMSG_PROPS_MAP_NIL, "missing-props", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_PROPS_MAP_NIL)
+		return nil, SDKErrorf(err, "", "missing-props", getComponentInfo())
 	}
 
 	disableSSL, err := strconv.ParseBool(properties[PROPNAME_AUTH_DISABLE_SSL])
@@ -315,13 +316,13 @@ func (authenticator *IamAuthenticator) Validate() error {
 	// normal use.
 	//
 	if authenticator.ApiKey == "" && authenticator.RefreshToken == "" {
-		errMsg := fmt.Sprintf(ERRORMSG_EXCLUSIVE_PROPS_ERROR, "ApiKey", "RefreshToken")
-		return SDKErrorf(nil, errMsg, "exc-props", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_EXCLUSIVE_PROPS_ERROR, "ApiKey", "RefreshToken")
+		return SDKErrorf(err, "", "exc-props", getComponentInfo())
 	}
 
 	if authenticator.ApiKey != "" && HasBadFirstOrLastChar(authenticator.ApiKey) {
-		errMsg := fmt.Sprintf(ERRORMSG_PROP_INVALID, "ApiKey")
-		return SDKErrorf(nil, errMsg, "bad-prop", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_PROP_INVALID, "ApiKey")
+		return SDKErrorf(err, "", "bad-prop", getComponentInfo())
 	}
 
 	// Validate ClientId and ClientSecret.
@@ -331,13 +332,13 @@ func (authenticator *IamAuthenticator) Validate() error {
 	} else {
 		// Since it is NOT the case that both properties are empty, make sure BOTH are specified.
 		if authenticator.ClientId == "" {
-			errMsg := fmt.Sprintf(ERRORMSG_PROP_MISSING, "ClientId")
-			return SDKErrorf(nil, errMsg, "missing-id", getComponentInfo())
+			err := fmt.Errorf(ERRORMSG_PROP_MISSING, "ClientId")
+			return SDKErrorf(err, "", "missing-id", getComponentInfo())
 		}
 
 		if authenticator.ClientSecret == "" {
-			errMsg := fmt.Sprintf(ERRORMSG_PROP_MISSING, "ClientSecret")
-			return SDKErrorf(nil, errMsg, "missing-secret", getComponentInfo())
+			err := fmt.Errorf(ERRORMSG_PROP_MISSING, "ClientSecret")
+			return SDKErrorf(err, "", "missing-secret", getComponentInfo())
 		}
 	}
 
@@ -362,7 +363,8 @@ func (authenticator *IamAuthenticator) GetToken() (string, error) {
 
 	// return an error if the access token is not valid or was not fetched
 	if authenticator.getTokenData() == nil || authenticator.getTokenData().AccessToken == "" {
-		return "", SDKErrorf(nil, "Error while trying to get access token", "no-token", getComponentInfo())
+		err := fmt.Errorf("Error while trying to get access token")
+		return "", SDKErrorf(err, "", "no-token", getComponentInfo())
 	}
 
 	return authenticator.getTokenData().AccessToken, nil
@@ -423,8 +425,8 @@ func (authenticator *IamAuthenticator) RequestToken() (*IamTokenServerResponse, 
 		builder.AddFormData("refresh_token", "", "", authenticator.RefreshToken)
 	} else {
 		// We shouldn't ever get here due to prior validations, but just in case, let's log an error.
-		errMsg := fmt.Sprintf(ERRORMSG_EXCLUSIVE_PROPS_ERROR, "ApiKey", "RefreshToken")
-		return nil, SDKErrorf(nil, errMsg, "iam-exc-props", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_EXCLUSIVE_PROPS_ERROR, "ApiKey", "RefreshToken")
+		return nil, SDKErrorf(err, "", "iam-exc-props", getComponentInfo())
 	}
 
 	// Add any optional parameters to the request.
@@ -529,7 +531,8 @@ type iamTokenData struct {
 func newIamTokenData(tokenResponse *IamTokenServerResponse) (*iamTokenData, error) {
 
 	if tokenResponse == nil {
-		return nil, SDKErrorf(nil, "Error while trying to parse access token!", "token-parse", getComponentInfo())
+		err := fmt.Errorf("Error while trying to parse access token!")
+		return nil, SDKErrorf(err, "", "token-parse", getComponentInfo())
 	}
 	// Compute the adjusted refresh time (expiration time - 20% of timeToLive)
 	timeToLive := tokenResponse.ExpiresIn

--- a/core/jwt_utils.go
+++ b/core/jwt_utils.go
@@ -32,7 +32,8 @@ func parseJWT(tokenString string) (claims *coreJWTClaims, err error) {
 	// A JWT consists of three .-separated segments
 	segments := strings.Split(tokenString, ".")
 	if len(segments) != 3 {
-		err = SDKErrorf(nil, "token contains an invalid number of segments", "need-3-segs", getComponentInfo())
+		err = fmt.Errorf("token contains an invalid number of segments")
+		err = SDKErrorf(err, "", "need-3-segs", getComponentInfo())
 		return
 	}
 

--- a/core/mcsp_authenticator.go
+++ b/core/mcsp_authenticator.go
@@ -139,7 +139,8 @@ func (authenticator *MCSPAuthenticator) client() *http.Client {
 // newMCSPAuthenticatorFromMap constructs a new MCSPAuthenticator instance from a map.
 func newMCSPAuthenticatorFromMap(properties map[string]string) (authenticator *MCSPAuthenticator, err error) {
 	if properties == nil {
-		return nil, SDKErrorf(nil, ERRORMSG_PROPS_MAP_NIL, "missing-props", getComponentInfo())
+		err = fmt.Errorf(ERRORMSG_PROPS_MAP_NIL)
+		return nil, SDKErrorf(err, "", "missing-props", getComponentInfo())
 	}
 
 	disableSSL, err := strconv.ParseBool(properties[PROPNAME_AUTH_DISABLE_SSL])
@@ -197,13 +198,13 @@ func (authenticator *MCSPAuthenticator) setTokenData(tokenData *mcspTokenData) {
 func (authenticator *MCSPAuthenticator) Validate() error {
 
 	if authenticator.ApiKey == "" {
-		errMsg := fmt.Sprintf(ERRORMSG_PROP_MISSING, "ApiKey")
-		return SDKErrorf(nil, errMsg, "missing-api-key", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_PROP_MISSING, "ApiKey")
+		return SDKErrorf(err, "", "missing-api-key", getComponentInfo())
 	}
 
 	if authenticator.URL == "" {
-		errMsg := fmt.Sprintf(ERRORMSG_PROP_MISSING, "URL")
-		return SDKErrorf(nil, errMsg, "missing-url", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_PROP_MISSING, "URL")
+		return SDKErrorf(err, "", "missing-url", getComponentInfo())
 	}
 
 	return nil
@@ -227,7 +228,8 @@ func (authenticator *MCSPAuthenticator) GetToken() (string, error) {
 
 	// return an error if the access token is not valid or was not fetched
 	if authenticator.getTokenData() == nil || authenticator.getTokenData().AccessToken == "" {
-		return "", SDKErrorf(nil, "Error while trying to get access token", "no-token", getComponentInfo())
+		err := fmt.Errorf("Error while trying to get access token")
+		return "", SDKErrorf(err, "", "no-token", getComponentInfo())
 	}
 
 	return authenticator.getTokenData().AccessToken, nil
@@ -368,7 +370,8 @@ type mcspTokenData struct {
 // MCSPTokenServerResponse instance.
 func newMCSPTokenData(tokenResponse *MCSPTokenServerResponse) (*mcspTokenData, error) {
 	if tokenResponse == nil || tokenResponse.Token == "" {
-		return nil, SDKErrorf(nil, "Error while trying to parse access token!", "token-parse", getComponentInfo())
+		err := fmt.Errorf("Error while trying to parse access token!")
+		return nil, SDKErrorf(err, "", "token-parse", getComponentInfo())
 	}
 
 	// Need to crack open the access token (a JWT) to get the expiration and issued-at times

--- a/core/request_builder.go
+++ b/core/request_builder.go
@@ -105,7 +105,7 @@ func (requestBuilder *RequestBuilder) WithContext(ctx context.Context) *RequestB
 // invalid URL string (e.g. ":<badscheme>").
 func (requestBuilder *RequestBuilder) ConstructHTTPURL(serviceURL string, pathSegments []string, pathParameters []string) (*RequestBuilder, error) {
 	if serviceURL == "" {
-		return requestBuilder, SDKErrorf(nil, ERRORMSG_SERVICE_URL_MISSING, "no-url", getComponentInfo())
+		return requestBuilder, SDKErrorf(fmt.Errorf(ERRORMSG_SERVICE_URL_MISSING), "", "no-url", getComponentInfo())
 	}
 	var URL *url.URL
 
@@ -143,7 +143,8 @@ func (requestBuilder *RequestBuilder) ConstructHTTPURL(serviceURL string, pathSe
 // The resulting request URL: "https://myservice.cloud.ibm.com/resource/res-123-456-789-abc/type/type-1"
 func (requestBuilder *RequestBuilder) ResolveRequestURL(serviceURL string, path string, pathParams map[string]string) (*RequestBuilder, error) {
 	if serviceURL == "" {
-		return requestBuilder, fmt.Errorf(ERRORMSG_SERVICE_URL_MISSING)
+		err := fmt.Errorf(ERRORMSG_SERVICE_URL_MISSING)
+		return requestBuilder, SDKErrorf(err, "", "service-url-missing", getComponentInfo())
 	}
 
 	urlString := serviceURL
@@ -156,8 +157,8 @@ func (requestBuilder *RequestBuilder) ResolveRequestURL(serviceURL string, path 
 		if len(pathParams) > 0 {
 			for k, v := range pathParams {
 				if v == "" {
-					errMsg := fmt.Sprintf(ERRORMSG_PATH_PARAM_EMPTY, k)
-					return requestBuilder, SDKErrorf(nil, errMsg, "empty-path-param", getComponentInfo())
+					err := fmt.Errorf(ERRORMSG_PATH_PARAM_EMPTY, k)
+					return requestBuilder, SDKErrorf(err, "", "empty-path-param", getComponentInfo())
 				}
 				encodedValue := url.PathEscape(v)
 				ref := fmt.Sprintf("{%s}", k)
@@ -506,12 +507,13 @@ func (requestBuilder *RequestBuilder) SetBodyContent(contentType string, jsonCon
 			err = RepurposeSDKProblem(err, "set-body-readerptr-error")
 		} else {
 			builder = requestBuilder
-			errMsg := fmt.Sprintf("Invalid type for non-JSON body content: %s", reflect.TypeOf(nonJSONContent).String())
-			err = SDKErrorf(nil, errMsg, "bad-nonjson-body-content", getComponentInfo())
+			err = fmt.Errorf("Invalid type for non-JSON body content: %s", reflect.TypeOf(nonJSONContent).String())
+			err = SDKErrorf(err, "", "bad-nonjson-body-content", getComponentInfo())
 		}
 	} else {
 		builder = requestBuilder
-		err = SDKErrorf(nil, "No body content provided", "no-body-content", getComponentInfo())
+		err = fmt.Errorf("No body content provided")
+		err = SDKErrorf(err, "", "no-body-content", getComponentInfo())
 	}
 
 	return

--- a/core/unmarshal_v2.go
+++ b/core/unmarshal_v2.go
@@ -78,7 +78,8 @@ const (
 // err = UnmarshalPrimitive(rawMessageMap, "field2", &myString.Field2)
 func UnmarshalPrimitive(rawInput map[string]json.RawMessage, propertyName string, result interface{}) (err error) {
 	if propertyName == "" {
-		err = SDKErrorf(nil, errorPropertyNameMissing, "no-prop-name", getComponentInfo())
+		err = fmt.Errorf(errorPropertyNameMissing)
+		err = SDKErrorf(err, "", "no-prop-name", getComponentInfo())
 	}
 
 	rawMsg, foundIt := rawInput[propertyName]
@@ -188,7 +189,8 @@ func UnmarshalModel(rawInput interface{}, propertyName string, result interface{
 
 	// Make sure some input is provided. Otherwise return an error.
 	if IsNil(rawInput) {
-		err = SDKErrorf(nil, errorUnmarshallInputIsNil, "no-input", getComponentInfo())
+		err = fmt.Errorf(errorUnmarshallInputIsNil)
+		err = SDKErrorf(err, "", "no-input", getComponentInfo())
 		return
 	}
 
@@ -221,13 +223,13 @@ func UnmarshalModel(rawInput interface{}, propertyName string, result interface{
 				err = unmarshalModelSliceSlice(rawInput, propertyName, result, unmarshaller)
 
 			default:
-				errMsg := fmt.Sprintf(errorUnsupportedResultType, rResultType.String())
-				err = SDKErrorf(nil, errMsg, "bad-slice-elem-slice-type", getComponentInfo())
+				err = fmt.Errorf(errorUnsupportedResultType, rResultType.String())
+				err = SDKErrorf(err, "", "bad-slice-elem-slice-type", getComponentInfo())
 			}
 
 		default:
-			errMsg := fmt.Sprintf(errorUnsupportedResultType, rResultType.String())
-			err = SDKErrorf(nil, errMsg, "bad-slice-elem-type", getComponentInfo())
+			err = fmt.Errorf(errorUnsupportedResultType, rResultType.String())
+			err = SDKErrorf(err, "", "bad-slice-elem-type", getComponentInfo())
 			return
 		}
 
@@ -248,19 +250,19 @@ func UnmarshalModel(rawInput interface{}, propertyName string, result interface{
 				err = unmarshalModelSliceMap(rawInput, propertyName, result, unmarshaller)
 
 			default:
-				errMsg := fmt.Sprintf(errorUnsupportedResultType, rResultType.String())
-				err = SDKErrorf(nil, errMsg, "bad-slice-elem-map-type", getComponentInfo())
+				err = fmt.Errorf(errorUnsupportedResultType, rResultType.String())
+				err = SDKErrorf(err, "", "bad-slice-elem-map-type", getComponentInfo())
 				return
 			}
 		default:
-			errMsg := fmt.Sprintf(errorUnsupportedResultType, rResultType.String())
-			err = SDKErrorf(nil, errMsg, "bad-map-entry-type", getComponentInfo())
+			err = fmt.Errorf(errorUnsupportedResultType, rResultType.String())
+			err = SDKErrorf(err, "", "bad-map-entry-type", getComponentInfo())
 			return
 		}
 
 	default:
-		errMsg := fmt.Sprintf(errorUnsupportedResultType, rResultType.String())
-		err = SDKErrorf(nil, errMsg, "bad-model-type", getComponentInfo())
+		err = fmt.Errorf(errorUnsupportedResultType, rResultType.String())
+		err = SDKErrorf(err, "", "bad-model-type", getComponentInfo())
 		return
 	}
 
@@ -663,8 +665,8 @@ func getUnmarshalInputSourceMap(rawInput interface{}, propertyName string) (foun
 	rawMap, ok := rawInput.(map[string]json.RawMessage)
 	if !ok {
 		foundInput = false
-		errMsg := fmt.Sprintf(errorIncorrectInputType, "map[string]json.RawMessage", reflect.TypeOf(rawInput).String())
-		err = SDKErrorf(nil, errMsg, "non-json-source-map", getComponentInfo())
+		err = fmt.Errorf(errorIncorrectInputType, "map[string]json.RawMessage", reflect.TypeOf(rawInput).String())
+		err = SDKErrorf(err, "", "non-json-source-map", getComponentInfo())
 		return
 	}
 
@@ -707,8 +709,8 @@ func getUnmarshalInputSourceSlice(rawInput interface{}, propertyName string) (fo
 	if propertyName != "" {
 		rawMap, ok := rawInput.(map[string]json.RawMessage)
 		if !ok {
-			errMsg := fmt.Sprintf(errorIncorrectInputType, "map[string]json.RawMessage", reflect.TypeOf(rawInput).String())
-			err = SDKErrorf(nil, errMsg, "raw-input-error", getComponentInfo())
+			err = fmt.Errorf(errorIncorrectInputType, "map[string]json.RawMessage", reflect.TypeOf(rawInput).String())
+			err = SDKErrorf(err, "", "raw-input-error", getComponentInfo())
 			return
 		}
 
@@ -736,8 +738,8 @@ func getUnmarshalInputSourceSlice(rawInput interface{}, propertyName string) (fo
 
 		rawSlice, ok := rawInput.([]json.RawMessage)
 		if !ok {
-			errMsg := fmt.Sprintf(errorIncorrectInputType, "[]json.RawMessage", reflect.TypeOf(rawInput).String())
-			err = SDKErrorf(nil, errMsg, "no-name-raw-input-error", getComponentInfo())
+			err = fmt.Errorf(errorIncorrectInputType, "[]json.RawMessage", reflect.TypeOf(rawInput).String())
+			err = SDKErrorf(err, "", "no-name-raw-input-error", getComponentInfo())
 			return
 		}
 
@@ -777,8 +779,8 @@ func getUnmarshalResultType(result interface{}) (ptrType reflect.Type, err error
 		ptrType = rResultType
 
 	default:
-		errMsg := fmt.Sprintf(errorUnsupportedResultType, rResultType.String())
-		err = SDKErrorf(nil, errMsg, "unsupported-type", getComponentInfo())
+		err = fmt.Errorf(errorUnsupportedResultType, rResultType.String())
+		err = SDKErrorf(err, "", "unsupported-type", getComponentInfo())
 	}
 	return
 }

--- a/core/utils.go
+++ b/core/utils.go
@@ -59,7 +59,8 @@ func IsNil(object interface{}) bool {
 // ValidateNotNil returns the specified error if 'object' is nil, nil otherwise.
 func ValidateNotNil(object interface{}, errorMsg string) error {
 	if IsNil(object) {
-		return SDKErrorf(nil, errorMsg, "obj-is-nil", getComponentInfo())
+		err := fmt.Errorf(errorMsg)
+		return SDKErrorf(err, "", "obj-is-nil", getComponentInfo())
 	}
 	return nil
 }
@@ -206,7 +207,8 @@ func ConvertSlice(slice interface{}) (s []string, err error) {
 	inputIsSlice := false
 
 	if IsNil(slice) {
-		err = SDKErrorf(nil, ERRORMSG_NIL_SLICE, "nil-slice", getComponentInfo())
+		err = fmt.Errorf(ERRORMSG_NIL_SLICE)
+		err = SDKErrorf(err, "", "nil-slice", getComponentInfo())
 		return
 	}
 
@@ -221,7 +223,8 @@ func ConvertSlice(slice interface{}) (s []string, err error) {
 
 	// If it's not a slice, just return an error
 	if !inputIsSlice {
-		err = SDKErrorf(nil, ERRORMSG_PARAM_NOT_SLICE, "param-not-slice", getComponentInfo())
+		err = fmt.Errorf(ERRORMSG_PARAM_NOT_SLICE)
+		err = SDKErrorf(err, "", "param-not-slice", getComponentInfo())
 		return
 	} else if reflect.ValueOf(slice).Len() == 0 {
 		s = []string{}
@@ -260,7 +263,8 @@ func ConvertSlice(slice interface{}) (s []string, err error) {
 		return
 	}
 
-	return nil, SDKErrorf(nil, ERRORMSG_CONVERT_SLICE, "cant-convert-slice", getComponentInfo())
+	err = fmt.Errorf(ERRORMSG_CONVERT_SLICE)
+	return nil, SDKErrorf(err, "", "cant-convert-slice", getComponentInfo())
 }
 
 // SliceContains returns true iff "contains" is an element of "slice"

--- a/core/vpc_instance_authenticator.go
+++ b/core/vpc_instance_authenticator.go
@@ -147,7 +147,8 @@ func (authenticator *VpcInstanceAuthenticator) url() string {
 // configuration properties.
 func newVpcInstanceAuthenticatorFromMap(properties map[string]string) (authenticator *VpcInstanceAuthenticator, err error) {
 	if properties == nil {
-		return nil, SDKErrorf(nil, ERRORMSG_PROPS_MAP_NIL, "missing-props", getComponentInfo())
+		err = fmt.Errorf(ERRORMSG_PROPS_MAP_NIL)
+		return nil, SDKErrorf(err, "", "missing-props", getComponentInfo())
 	}
 
 	authenticator, err = NewVpcInstanceAuthenticatorBuilder().
@@ -203,8 +204,8 @@ func (authenticator *VpcInstanceAuthenticator) Validate() error {
 
 	// Check to make sure that at most one of IAMProfileCRN or IAMProfileID are specified.
 	if authenticator.IAMProfileCRN != "" && authenticator.IAMProfileID != "" {
-		errMsg := fmt.Sprintf(ERRORMSG_ATMOST_ONE_PROP_ERROR, "IAMProfileCRN", "IAMProfileID")
-		return SDKErrorf(nil, errMsg, "both-props", getComponentInfo())
+		err := fmt.Errorf(ERRORMSG_ATMOST_ONE_PROP_ERROR, "IAMProfileCRN", "IAMProfileID")
+		return SDKErrorf(err, "", "both-props", getComponentInfo())
 	}
 
 	return nil
@@ -232,7 +233,8 @@ func (authenticator *VpcInstanceAuthenticator) GetToken() (string, error) {
 
 	// return an error if the access token is not valid or was not fetched
 	if authenticator.getTokenData() == nil || authenticator.getTokenData().AccessToken == "" {
-		return "", SDKErrorf(nil, "Error while trying to get access token", "no-token", getComponentInfo())
+		err := fmt.Errorf("Error while trying to get access token")
+		return "", SDKErrorf(err, "", "no-token", getComponentInfo())
 	}
 
 	return authenticator.getTokenData().AccessToken, nil


### PR DESCRIPTION
I missed an error origination point that needed to be converted to the new format. Also, this is maybe overly cautious but I added back in the original error instances as native caused by errors for all instances. Before, I intentionally left alone places that held an error origination from `fmt.Errorf()` because I don't know that users can really match against those, but I figured we might as well be as compatibility-friendly as we can be, since it doesn't cost us anything.