### PR TITLE
feat: send user-agent header with auth token requests

### DIFF
--- a/core/container_authenticator_test.go
+++ b/core/container_authenticator_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 
 	"testing"
 	"time"
@@ -257,6 +258,8 @@ func startMockIAMServer(t *testing.T) *httptest.Server {
 			// then validate it a bit and then send back a good response.
 			assert.Equal(t, APPLICATION_JSON, req.Header.Get("Accept"))
 			assert.Equal(t, FORM_URL_ENCODED_HEADER, req.Header.Get("Content-Type"))
+			assert.True(t, strings.HasPrefix(req.Header.Get(headerNameUserAgent),
+				fmt.Sprintf("%s/%s", sdkName, "container-authenticator")))
 			assert.Equal(t, containerAuthTestCRToken1, req.FormValue("cr_token"))
 			assert.Equal(t, iamGrantTypeCRToken, req.FormValue("grant_type"))
 

--- a/core/cp4d_authenticator_test.go
+++ b/core/cp4d_authenticator_test.go
@@ -2,7 +2,7 @@
 
 package core
 
-// (C) Copyright IBM Corp. 2019, 2021.
+// (C) Copyright IBM Corp. 2019, 2024.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -585,6 +585,8 @@ func TestCp4dUserHeaders(t *testing.T) {
 		assert.Equal(t, "Value1", r.Header.Get("Header1"))
 		assert.Equal(t, "Value2", r.Header.Get("Header2"))
 		assert.Equal(t, "cp4d.cloud.ibm.com", r.Host)
+		assert.True(t, strings.HasPrefix(r.Header.Get(headerNameUserAgent),
+			fmt.Sprintf("%s/%s", sdkName, "cp4d-authenticator")))
 
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, `{ "_messageCode_":"200", "message":"success", "token":"%s"}`, cp4dUsernameApikey1)

--- a/core/iam_authenticator_test.go
+++ b/core/iam_authenticator_test.go
@@ -965,6 +965,8 @@ func TestIamUserHeaders(t *testing.T) {
 		assert.False(t, ok)
 		assert.Equal(t, "Value1", r.Header.Get("Header1"))
 		assert.Equal(t, "Value2", r.Header.Get("Header2"))
+		assert.True(t, strings.HasPrefix(r.Header.Get(headerNameUserAgent),
+			fmt.Sprintf("%s/%s", sdkName, "iam-authenticator")))
 		assert.Equal(t, "iam.cloud.ibm.com", r.Host)
 	}))
 	defer server.Close()

--- a/core/mcsp_authenticator_test.go
+++ b/core/mcsp_authenticator_test.go
@@ -2,7 +2,7 @@
 
 package core
 
-// (C) Copyright IBM Corp. 2023.
+// (C) Copyright IBM Corp. 2023, 2024.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -467,6 +467,8 @@ func TestMCSPUserHeaders(t *testing.T) {
 		fmt.Fprintf(w, `{"token":"%s","token_type":"jwt","expires_in":7200}`, mcspAuthTestAccessToken1)
 		assert.Equal(t, "Value1", r.Header.Get("Header1"))
 		assert.Equal(t, "Value2", r.Header.Get("Header2"))
+		assert.True(t, strings.HasPrefix(r.Header.Get(headerNameUserAgent),
+			fmt.Sprintf("%s/%s", sdkName, "mcsp-authenticator")))
 		assert.Equal(t, "mcsp.cloud.ibm.com", r.Host)
 	}))
 	defer server.Close()

--- a/core/vpc_instance_authenticator_test.go
+++ b/core/vpc_instance_authenticator_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -293,6 +294,8 @@ func startMockVPCServer(t *testing.T, scenario string) *httptest.Server {
 			assert.NotEmpty(t, req.URL.Query().Get("version"))
 			assert.Equal(t, APPLICATION_JSON, req.Header.Get("Accept"))
 			assert.Equal(t, APPLICATION_JSON, req.Header.Get("Content-Type"))
+			assert.True(t, strings.HasPrefix(req.Header.Get(headerNameUserAgent),
+				fmt.Sprintf("%s/%s", sdkName, "vpc-instance-authenticator")))
 			assert.Equal(t, expectedAuthorizationHeader, req.Header.Get("Authorization"))
 
 			// Models a trusted profile (includes both CRN and ID fields).


### PR DESCRIPTION
This commit updates our various request-based authenticators so that the User-Agent header is included with each outbound token request. The value of the User-Agent header will be of the form "ibm-go-sdk-core/<authenticator-type>-<core-version> <os-info>".