### PR TITLE
fix(errors): flatten sdk problem chains to reduce hash complexity

### DIFF
--- a/core/base_service.go
+++ b/core/base_service.go
@@ -389,7 +389,7 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 		var sdkErr *SDKProblem
 		if errors.As(authenticateError, &authErr) {
 			detailedResponse = authErr.Response
-			err = SDKErrorf(authErr.HTTPProblem, fmt.Sprintf(ERRORMSG_AUTHENTICATE_ERROR, authErr.Error()), "auth-failed", getComponentInfo())
+			err = SDKErrorf(authErr.HTTPProblem, fmt.Sprintf(ERRORMSG_AUTHENTICATE_ERROR, authErr.Error()), "auth-request-failed", getComponentInfo())
 		} else if errors.As(authenticateError, &sdkErr) {
 			sdkErr := RepurposeSDKProblem(authenticateError, "auth-failed")
 			// For compatibility.

--- a/core/sdk_problem_utils.go
+++ b/core/sdk_problem_utils.go
@@ -106,3 +106,19 @@ func formatFrames(pcs []uintptr, componentName string) []sdkStackFrame {
 
 	return result
 }
+
+type sparseSDKProblem struct {
+	ID string
+	Function string
+}
+
+func newSparseSDKProblem(prob *SDKProblem) *sparseSDKProblem {
+	return &sparseSDKProblem{
+		ID: prob.GetID(),
+		Function: prob.Function,
+	}
+}
+
+func isCoreProblem(prob *SDKProblem) bool {
+	return prob.Component != nil && prob.Component.Name == MODULE_NAME
+}


### PR DESCRIPTION
Previously, any SDKProblem instance could be used as the "caused by" for another SDKProblem instance and its ID would become a part of the hash. This meant that problems created between service SDKs and the Go SDK Core would have a lot of complexity - the error scenarios tracked would be unnecessarily granular and numerous.

This change updates the system to maintain one problem scenario per *context* (where a context is either HTTP, SDK, or Terraform) rather than per every component within a given context.

It also provides for keeping knowledge of problem scenarios originating in the core for easier debugging and easier attaching of HTTP errors to service SDK problems.