### PR TITLE
fix(request_builder): encode unresolved path string prior to path parameter insertion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test:
 
 lint:
 	${LINT} run --build-tags=all
-	DIFF=$$(${FORMATTER} -d core); if [[ -n "$$DIFF" ]]; then printf "\n$$DIFF" && exit 1; fi
+	DIFF=$$(${FORMATTER} -d core); if [ -n "$$DIFF" ]; then printf "\n$$DIFF\n" && exit 1; fi
 
 scan-gosec:
 	${GOSEC} ./...

--- a/core/request_builder.go
+++ b/core/request_builder.go
@@ -152,6 +152,14 @@ func (requestBuilder *RequestBuilder) ResolveRequestURL(serviceURL string, path 
 	// If we have a non-empty "path" input parameter, then process it for possible path param references.
 	if path != "" {
 
+		// Encode the unresolved path string.  This will convert all special characters to their
+		// "%" encoding counterparts.  Then we need to revert the encodings for '/', '{' and '}' characters
+		// to retain the original path segments and to make it easy to insert the encoded path param values below.
+		path = url.PathEscape(path)
+		path = strings.ReplaceAll(path, "%2F", "/")
+		path = strings.ReplaceAll(path, "%7B", "{")
+		path = strings.ReplaceAll(path, "%7D", "}")
+
 		// If path parameter values were passed in, then for each one, replace any references to it
 		// within "path" with the path parameter's encoded value.
 		if len(pathParams) > 0 {

--- a/core/sdk_problem_test.go
+++ b/core/sdk_problem_test.go
@@ -239,7 +239,7 @@ func TestSDKErrorfNoSummary(t *testing.T) {
 }
 
 func TestSDKErrorfDoesntUseSDKCausedBy(t *testing.T) {
-	sdkProb := getPopulatedSDKProblem();
+	sdkProb := getPopulatedSDKProblem()
 	newSDKProb := SDKErrorf(sdkProb, "", "", NewProblemComponent("a", "b"))
 	assert.Nil(t, newSDKProb.causedBy)
 	assert.NotNil(t, newSDKProb.nativeCausedBy)

--- a/core/sdk_problem_utils.go
+++ b/core/sdk_problem_utils.go
@@ -108,13 +108,13 @@ func formatFrames(pcs []uintptr, componentName string) []sdkStackFrame {
 }
 
 type sparseSDKProblem struct {
-	ID string
+	ID       string
 	Function string
 }
 
 func newSparseSDKProblem(prob *SDKProblem) *sparseSDKProblem {
 	return &sparseSDKProblem{
-		ID: prob.GetID(),
+		ID:       prob.GetID(),
 		Function: prob.Function,
 	}
 }


### PR DESCRIPTION
This commit modifies RequestBuilder.ResolveRequestURL() slightly so that the passed-in path string (unresolved, potentially containing special characters and path parameter references) is URL-encoded prior to replacing path param references with their corresponding encoded path param values.  This ensures that the URL string passed to http.NewRequest() by RequestBuilder.Build() will be properly encoded (escaped) such that all special characters appearing in path segments are converted to their %nn equivalents, but yet any escaped characters within the encoded path param values are NOT decoded.  This avoids a quirk in the url.Parse() method that is invoked by the http.NewRequest() method.

This change is needed in order to properly support a scenario where:
1. a path parameter value contains one or more embedded slashes and is therefore escaped AND
2. the unresolved path string ALSO contains other special characters needing to be escaped