### PR TITLE
fix: wrap full validation errors instead of just their message

### DIFF
--- a/core/utils.go
+++ b/core/utils.go
@@ -79,7 +79,7 @@ func ValidateStruct(param interface{}, paramName string) error {
 	if err != nil {
 		// If there were validation errors then return an error containing the field errors
 		if fieldErrors, ok := err.(validator.ValidationErrors); ok {
-			err = fmt.Errorf("%s failed validation:\n%s", paramName, fieldErrors.Error())
+			err = fmt.Errorf("%s failed validation:\n%w", paramName, fieldErrors)
 			return SDKErrorf(err, "", "struct-validation-errors", getComponentInfo())
 		}
 		return SDKErrorf(err, "", "struct-validate-unknown-error", getComponentInfo())


### PR DESCRIPTION
This PR contains a simple adjustment to error handling of the struct field validation.
Previously only the string representation of the error was included in the returned
`SDKError`, but an upcoming change to the CLI plugins requires the actual error
object, because it contains valuable information.