### PR TITLE
fix(BaseService): allow User-Agent to be set via service-level headers

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-05-27T21:35:43Z",
+  "generated_at": "2025-06-10T15:52:17Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -148,7 +148,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 921,
+        "line_number": 928,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -158,7 +158,7 @@
         "hashed_secret": "1f5e25be9b575e9f5d39c82dfd1d9f4d73f1975c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1289,
+        "line_number": 1340,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -166,7 +166,7 @@
         "hashed_secret": "84ba4ce8a59ed2d6e90726d57cdc4a927d3672b2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1532,
+        "line_number": 1583,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -174,7 +174,7 @@
         "hashed_secret": "62cdb7020ff920e5aa642c3d4066950dd1f01f4d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1578,
+        "line_number": 1629,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -182,7 +182,7 @@
         "hashed_secret": "ec7ec9d8ff520250fd5ca955c6474c6d70022407",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1586,
+        "line_number": 1637,
         "type": "JSON Web Token",
         "verified_result": null
       },
@@ -190,7 +190,7 @@
         "hashed_secret": "40ce4379f5763c05b71c88f9a371809fdbce6a21",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1683,
+        "line_number": 1734,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -198,7 +198,7 @@
         "hashed_secret": "9addbf544119efa4a64223b649750a510f0d463f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1710,
+        "line_number": 1761,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/core/base_service.go
+++ b/core/base_service.go
@@ -357,13 +357,13 @@ func (service *BaseService) SetUserAgent(userAgent string) {
 //
 // err: a non-nil error object if an error occurred
 func (service *BaseService) Request(req *http.Request, result interface{}) (detailedResponse *DetailedResponse, err error) {
-	// Add default headers.
+	// Set default headers on the request.
 	if service.DefaultHeaders != nil {
 		for k, v := range service.DefaultHeaders {
-			req.Header.Add(k, strings.Join(v, ""))
+			req.Header.Set(k, strings.Join(v, ""))
 		}
 
-		// After adding the default headers, make one final check to see if the user
+		// After setting the default headers, make one final check to see if the user
 		// specified the "Host" header within the default headers.
 		// This needs to be handled separately because it will be ignored by
 		// the Request.Write() method.


### PR DESCRIPTION
This commit modifies the Go core's BaseService.Request() method slightly so that when setting service-level custom headers on the outbound request, it will now replace any existing header with the service-level header value, rather than add the service-level header value to the existing value that might already exist.
The net effect of this is that a User-Agent header set as a service-level default header will now override a User-Agent header set by an SDK project through its "common.GetSdkHeaders()" function.