### PR TITLE
build: exclude some gosec rules from golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,10 +10,9 @@ linters:
       - std-error-handling
   settings:
     gosec:
-      includes:
-        - all
-        - -G703
-        - -G704
+      excludes:
+        - G703
+        - G704
     staticcheck:
       checks:
         - all

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,6 +9,11 @@ linters:
       - legacy
       - std-error-handling
   settings:
+    gosec:
+      includes:
+        - all
+        - -G703
+        - -G704
     staticcheck:
       checks:
         - all

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,8 +11,12 @@ linters:
   settings:
     gosec:
       excludes:
+        - G101
+        - G117
+        - G120
         - G703
         - G704
+        - G705
     staticcheck:
       checks:
         - all


### PR DESCRIPTION
`golangci-lint` needed to be upgraded for the builds to run with Go version `1.26`. Because of this some newly added rules had to be disabled.