### PR TITLE
fix: check dumpErr instead of err when logging HTTP response

### DIFF
--- a/core/base_service.go
+++ b/core/base_service.go
@@ -432,7 +432,7 @@ func (service *BaseService) Request(req *http.Request, result interface{}) (deta
 	// If debug is enabled, then dump the response.
 	if GetLogger().IsLogLevelEnabled(LevelDebug) {
 		buf, dumpErr := httputil.DumpResponse(httpResponse, !IsNil(httpResponse.Body))
-		if err == nil {
+		if dumpErr == nil {
 			GetLogger().Debug("Response:\n%s\n", RedactSecrets(string(buf)))
 		} else {
 			GetLogger().Debug("error while attempting to log inbound response: %s", dumpErr.Error())


### PR DESCRIPTION
When debug logging is enabled, the code calls httputil.DumpResponse() and stores the error in dumpErr, but the condition to decide whether to log the response was checking err
instead of dumpErr.

At this point in the execution flow, any non-nil err would have already triggered an early return (line 428), so err is always nil here. This caused two problems:
The response body was always logged, even when DumpResponse() failed.
The error branch (dumpErr.Error()) was never reached, silently swallowing dump errors.

Fix: Replace if err == nil with if dumpErr == nil on line 435.