### PR TITLE
chore: clarify the usage of the credentials env file

### DIFF
--- a/resources/ibm-credentials.env
+++ b/resources/ibm-credentials.env
@@ -1,3 +1,6 @@
+# These credentials are for local development and testing only.
+# They are not included in the published package and do NOT
+# provide access to any production or sensitive systems.
 #
 MY_SERVICE1_URL=https://cp4d.com
 MY_SERVICE1_AUTH_TYPE=cp4d

--- a/resources/my-credentials.env
+++ b/resources/my-credentials.env
@@ -1,3 +1,7 @@
+# These credentials are for local development and testing only.
+# They are not included in the published package and do NOT
+# provide access to any production or sensitive systems.
+
 # Service-specific properties not related to authentication.
 SERVICE_1_URL=https://service1/api
 SERVICE_1_DISABLE_SSL=true


### PR DESCRIPTION
The CISO team requested to make it clear that the env file included in this repository doesn't contain any sensitive/real data and it's just for testing.