### PR TITLE
feat(auth): add new IAM profile selector to VPC Instance Auth

### DIFF
--- a/Authentication.md
+++ b/Authentication.md
@@ -598,11 +598,13 @@ The IAM access token is added to each outbound request in the `Authorization` he
 
 ### Properties
 
-- IAMProfileCRN: (optional) the crn of the linked trusted IAM profile to be used when obtaining the IAM access token. 
+- IAMProfileCRN: (optional) the crn of the linked trusted IAM profile to be used when obtaining the IAM access token.
 
 - IAMProfileID: (optional) the id of the linked trusted IAM profile to be used when obtaining the IAM access token.
 
-- URL: (optional) The base endpoint URL of the VPC Instance Metadata Service.  
+- IAMProfileName: (optional) the name of the linekd trusted IAM profile to be used when obtaining the IAM access token.
+
+- URL: (optional) The base endpoint URL of the VPC Instance Metadata Service.
 The default value of this property is `http://169.254.169.254`.  However, if the VPC Instance Metadata Service is configured
 with the HTTP Secure Protocol setting (`https`), then you should configure this property to be `https://api.metadata.cloud.ibm.com`.
 
@@ -617,12 +619,12 @@ The default value is `300` seconds. This property can only be configured program
 If not specified by the user, a suitable default Client will be constructed.
 
 Usage Notes:
-1. At most one of `IAMProfileCRN` or `IAMProfileID` may be specified.  The specified value must map
+1. At most one of `IAMProfileCRN`, `IAMProfileID` or `IAMProfileName` may be specified.  The specified value must map
 to a trusted IAM profile that has been linked to the compute resource (virtual server instance).
 
-2. If both `IAMProfileCRN` and `IAMProfileID` are specified, then an error occurs.
+2. If more than on from `IAMProfileCRN`, `IAMProfileID` or `IAMProfileName` are specified, then an error occurs.
 
-3. If neither `IAMProfileCRN` nor `IAMProfileID` are specified, then the default trusted profile linked to the 
+3. If neither `IAMProfileCRN`, `IAMProfileID` nor `IAMProfileName` are specified, then the default trusted profile linked to the
 compute resource will be used to perform the IAM token exchange.
 If no default trusted profile is defined for the compute resource, then an error occurs.
 

--- a/Authentication.md
+++ b/Authentication.md
@@ -602,7 +602,7 @@ The IAM access token is added to each outbound request in the `Authorization` he
 
 - IAMProfileID: (optional) the id of the linked trusted IAM profile to be used when obtaining the IAM access token.
 
-- IAMProfileName: (optional) the name of the linekd trusted IAM profile to be used when obtaining the IAM access token.
+- IAMProfileName: (optional) the name of the linked trusted IAM profile to be used when obtaining the IAM access token.
 
 - URL: (optional) The base endpoint URL of the VPC Instance Metadata Service.
 The default value of this property is `http://169.254.169.254`.  However, if the VPC Instance Metadata Service is configured
@@ -622,7 +622,7 @@ Usage Notes:
 1. At most one of `IAMProfileCRN`, `IAMProfileID` or `IAMProfileName` may be specified.  The specified value must map
 to a trusted IAM profile that has been linked to the compute resource (virtual server instance).
 
-2. If more than on from `IAMProfileCRN`, `IAMProfileID` or `IAMProfileName` are specified, then an error occurs.
+2. If more than one of `IAMProfileCRN`, `IAMProfileID` or `IAMProfileName` are specified, then an error occurs.
 
 3. If neither `IAMProfileCRN`, `IAMProfileID` nor `IAMProfileName` are specified, then the default trusted profile linked to the
 compute resource will be used to perform the IAM token exchange.

--- a/core/constants.go
+++ b/core/constants.go
@@ -72,7 +72,7 @@ const (
 	ERRORMSG_PROP_INVALID            = "The %s property is invalid. Please remove any surrounding {, }, or \" characters."
 	ERRORMSG_EXCLUSIVE_PROPS_ERROR   = "Exactly one of %s or %s must be specified."
 	ERRORMSG_ATLEAST_ONE_PROP_ERROR  = "At least one of %s or %s must be specified."
-	ERRORMSG_ATMOST_ONE_PROP_ERROR   = "At most one of %s or %s may be specified."
+	ERRORMSG_ATMOST_ONE_PROP_ERROR   = "At most one of %s, %s, or %s may be specified."
 	ERRORMSG_NO_AUTHENTICATOR        = "Authentication information was not properly configured."
 	ERRORMSG_AUTHTYPE_UNKNOWN        = "Unrecognized authentication type: %s"
 	ERRORMSG_PROPS_MAP_NIL           = "The 'properties' map cannot be nil."

--- a/core/vpc_instance_authenticator.go
+++ b/core/vpc_instance_authenticator.go
@@ -39,16 +39,22 @@ import (
 //	Authorization: Bearer <access-token>
 type VpcInstanceAuthenticator struct {
 	// [optional] The CRN of the linked trusted IAM profile to be used as the identity of the compute resource.
-	// At most one of IAMProfileCRN or IAMProfileID may be specified.  If neither one is specified, then
+	// At most one of IAMProfileCRN, IAMProfileID or IAMProfileName may be specified.  If neither one is specified, then
 	// the default IAM profile defined for the compute resource will be used.
 	// Default value: ""
 	IAMProfileCRN string
 
 	// [optional] The ID of the linked trusted IAM profile to be used when obtaining the IAM access token.
-	// At most one of IAMProfileCRN or IAMProfileID may be specified.  If neither one is specified, then
+	// At most one of IAMProfileCRN, IAMProfileID or IAMProfileName may be specified.  If neither one is specified, then
 	// the default IAM profile defined for the compute resource will be used.
 	// Default value: ""
 	IAMProfileID string
+
+	// [optional] The name of the linked trusted IAM profile to be used when obtaining the IAM access token.
+	// At most one of IAMProfileCRN, IAMProfileID or IAMProfileName may be specified.  If neither one is specified, then
+	// the default IAM profile defined for the compute resource will be used.
+	// Default value: ""
+	IAMProfileName string
 
 	// [optional] The VPC Instance Metadata Service's base endpoint URL.
 	// Default value: "http://169.254.169.254"
@@ -116,6 +122,12 @@ func (builder *VpcInstanceAuthenticatorBuilder) SetIAMProfileCRN(s string) *VpcI
 // SetIAMProfileID sets the IAMProfileID field in the builder.
 func (builder *VpcInstanceAuthenticatorBuilder) SetIAMProfileID(s string) *VpcInstanceAuthenticatorBuilder {
 	builder.VpcInstanceAuthenticator.IAMProfileID = s
+	return builder
+}
+
+// SetIAMProfileName sets the IAMProfileName field in the builder.
+func (builder *VpcInstanceAuthenticatorBuilder) SetIAMProfileName(s string) *VpcInstanceAuthenticatorBuilder {
+	builder.VpcInstanceAuthenticator.IAMProfileName = s
 	return builder
 }
 
@@ -230,6 +242,7 @@ func newVpcInstanceAuthenticatorFromMap(properties map[string]string) (authentic
 	authenticator, err = NewVpcInstanceAuthenticatorBuilder().
 		SetIAMProfileCRN(properties[PROPNAME_IAM_PROFILE_CRN]).
 		SetIAMProfileID(properties[PROPNAME_IAM_PROFILE_ID]).
+		SetIAMProfileName(properties[PROPNAME_IAM_PROFILE_NAME]).
 		SetURL(properties[PROPNAME_AUTH_URL]).
 		SetServiceVersion(properties[PROPNAME_VPC_IMS_VERSION]).
 		Build()
@@ -276,12 +289,21 @@ func (authenticator *VpcInstanceAuthenticator) setTokenData(tokenData *iamTokenD
 
 // Validate the authenticator's configuration.
 //
-// Ensures that one of IAMProfileName or IAMProfileID are specified, and the ClientId and ClientSecret pair are
-// mutually inclusive.
+// Ensures that at most one of IAMProfileCRN, IAMProfileID, or IAMProfileName is specified.
 func (authenticator *VpcInstanceAuthenticator) Validate() error {
-	// Check to make sure that at most one of IAMProfileCRN or IAMProfileID are specified.
-	if authenticator.IAMProfileCRN != "" && authenticator.IAMProfileID != "" {
-		err := fmt.Errorf(ERRORMSG_ATMOST_ONE_PROP_ERROR, "IAMProfileCRN", "IAMProfileID")
+	// Check to make sure that at most one of IAMProfileCRN, IAMProfileID, or IAMProfileName are specified.
+	counter := 0
+	if authenticator.IAMProfileCRN != "" {
+		counter++
+	}
+	if authenticator.IAMProfileID != "" {
+		counter++
+	}
+	if authenticator.IAMProfileName != "" {
+		counter++
+	}
+	if counter > 1 {
+		err := fmt.Errorf(ERRORMSG_ATMOST_ONE_PROP_ERROR, "IAMProfileCRN", "IAMProfileID", "IAMProfileName")
 		return SDKErrorf(err, "", "both-props", getComponentInfo())
 	}
 
@@ -430,6 +452,9 @@ func (authenticator *VpcInstanceAuthenticator) retrieveIamAccessToken(
 	}
 	if authenticator.IAMProfileID != "" {
 		requestBody = fmt.Sprintf(`{"trusted_profile": {"id": "%s"}}`, authenticator.IAMProfileID)
+	}
+	if authenticator.IAMProfileName != "" {
+		requestBody = fmt.Sprintf(`{"trusted_profile": {"name": "%s"}}`, authenticator.IAMProfileName)
 	}
 	if requestBody != "" {
 		_, _ = builder.SetBodyContentString(requestBody)

--- a/core/vpc_instance_authenticator_test.go
+++ b/core/vpc_instance_authenticator_test.go
@@ -35,6 +35,7 @@ const (
 	vpcauthTestLogLevel              LogLevel = LevelError
 	vpcauthMockIAMProfileCRN         string   = "crn:iam-profile:123"
 	vpcauthMockIAMProfileID          string   = "iam-id-123"
+	vpcauthMockIAMProfileName        string   = "iam-profile-name-123"
 	vpcauthMockNewServiceVersion     string   = "2025-08-26"
 	vpcauthMockURL                   string   = "http://vpc.metadata.service.com"
 	vpcauthTestAccessToken1          string   = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI"       // #nosec
@@ -50,10 +51,26 @@ func TestVpcAuthCtorErrors(t *testing.T) {
 	var err error
 	var auth *VpcInstanceAuthenticator
 
-	// Error: both IAMProfileCRN and IBMProfileID are specified
+	// Error: both IAMProfileCRN and IAMProfileID are specified
 	auth, err = NewVpcInstanceAuthenticatorBuilder().
 		SetIAMProfileCRN(vpcauthMockIAMProfileCRN).
 		SetIAMProfileID(vpcauthMockIAMProfileID).Build()
+	assert.NotNil(t, err)
+	assert.Nil(t, auth)
+	t.Logf("Expected error: %s", err.Error())
+
+	// Error: both IAMProfileCRN and IAMProfileName are specified
+	auth, err = NewVpcInstanceAuthenticatorBuilder().
+		SetIAMProfileCRN(vpcauthMockIAMProfileCRN).
+		SetIAMProfileName(vpcauthMockIAMProfileName).Build()
+	assert.NotNil(t, err)
+	assert.Nil(t, auth)
+	t.Logf("Expected error: %s", err.Error())
+
+	// Error: both IAMProfileID and IAMProfileName are specified
+	auth, err = NewVpcInstanceAuthenticatorBuilder().
+		SetIAMProfileID(vpcauthMockIAMProfileID).
+		SetIAMProfileName(vpcauthMockIAMProfileName).Build()
 	assert.NotNil(t, err)
 	assert.Nil(t, auth)
 	t.Logf("Expected error: %s", err.Error())
@@ -94,7 +111,19 @@ func TestVpcAuthCtorSuccess(t *testing.T) {
 	assert.Equal(t, vpcauthMockIAMProfileID, auth.IAMProfileID)
 	assert.Equal(t, "", auth.URL)
 
-	// 3. only URL
+	// 3. only IAMProfileName
+	auth, err = NewVpcInstanceAuthenticatorBuilder().
+		SetIAMProfileName(vpcauthMockIAMProfileName).
+		Build()
+	assert.Nil(t, err)
+	assert.NotNil(t, auth)
+	assert.Equal(t, AUTHTYPE_VPC, auth.AuthenticationType())
+	assert.Equal(t, "", auth.IAMProfileCRN)
+	assert.Equal(t, "", auth.IAMProfileID)
+	assert.Equal(t, vpcauthMockIAMProfileName, auth.IAMProfileName)
+	assert.Equal(t, "", auth.URL)
+
+	// 4. only URL
 	auth, err = NewVpcInstanceAuthenticatorBuilder().
 		SetURL(vpcauthMockURL).
 		Build()
@@ -133,6 +162,16 @@ func TestVpcAuthCtorFromMapErrors(t *testing.T) {
 	configProps = map[string]string{
 		PROPNAME_IAM_PROFILE_CRN: vpcauthMockIAMProfileCRN,
 		PROPNAME_IAM_PROFILE_ID:  vpcauthMockIAMProfileID,
+	}
+	auth, err = newVpcInstanceAuthenticatorFromMap(configProps)
+	assert.NotNil(t, err)
+	assert.Nil(t, auth)
+	t.Logf("Expected error: %s", err.Error())
+
+	// Error: both IAMProfileCRN and IAMProfileName specified
+	configProps = map[string]string{
+		PROPNAME_IAM_PROFILE_CRN:  vpcauthMockIAMProfileCRN,
+		PROPNAME_IAM_PROFILE_NAME: vpcauthMockIAMProfileName,
 	}
 	auth, err = newVpcInstanceAuthenticatorFromMap(configProps)
 	assert.NotNil(t, err)
@@ -179,7 +218,20 @@ func TestVpcAuthCtorFromMapSuccess(t *testing.T) {
 	assert.Equal(t, vpcauthMockIAMProfileID, auth.IAMProfileID)
 	assert.Equal(t, "", auth.URL)
 
-	// 4. only URL
+	// 4. only IAMProfileName
+	configProps = map[string]string{
+		PROPNAME_IAM_PROFILE_NAME: vpcauthMockIAMProfileName,
+	}
+	auth, err = newVpcInstanceAuthenticatorFromMap(configProps)
+	assert.Nil(t, err)
+	assert.NotNil(t, auth)
+	assert.Equal(t, AUTHTYPE_VPC, auth.AuthenticationType())
+	assert.Equal(t, "", auth.IAMProfileCRN)
+	assert.Equal(t, "", auth.IAMProfileID)
+	assert.Equal(t, vpcauthMockIAMProfileName, auth.IAMProfileName)
+	assert.Equal(t, "", auth.URL)
+
+	// 5. only URL
 	configProps = map[string]string{
 		PROPNAME_AUTH_URL: vpcauthMockURL,
 	}
@@ -299,13 +351,16 @@ func startMockVPCServer(t *testing.T, scenario string) *httptest.Server {
 			assert.Equal(t, expectedAuthorizationHeader, req.Header.Get("Authorization"))
 			assert.Equal(t, vpcauthMetadataFlavor, req.Header.Get("Metadata-Flavor"))
 
-			// Models a trusted profile (includes both CRN and ID fields).
+			// Models a trusted profile (includes CRN, ID, and Name fields).
 			type trustedProfileIdentity struct {
 				// The unique identifier for this trusted profile.
 				ID *string `json:"id,omitempty"`
-
+	
 				// The CRN for this trusted profile.
 				CRN *string `json:"crn,omitempty"`
+	
+				// The name of this trusted profile.
+				Name *string `json:"name,omitempty"`
 			}
 
 			// Models the request body for the 'create_iam_token' operation.
@@ -335,7 +390,17 @@ func startMockVPCServer(t *testing.T, scenario string) *httptest.Server {
 				assert.NotNil(t, requestBody.TrustedProfile)
 				assert.Nil(t, requestBody.TrustedProfile.CRN)
 				assert.NotNil(t, requestBody.TrustedProfile.ID)
+				assert.Nil(t, requestBody.TrustedProfile.Name)
 				assert.Equal(t, vpcauthMockIAMProfileID, *requestBody.TrustedProfile.ID)
+	
+			case "profile-name":
+				assert.NotNil(t, requestBody)
+				assert.NotNil(t, requestBody.TrustedProfile)
+				assert.Nil(t, requestBody.TrustedProfile.CRN)
+				assert.Nil(t, requestBody.TrustedProfile.ID)
+				assert.NotNil(t, requestBody.TrustedProfile.Name)
+				assert.Equal(t, vpcauthMockIAMProfileName, *requestBody.TrustedProfile.Name)
+	
 			case "new-service-version":
 				assert.NotNil(t, requestBody)
 				assert.Equal(t, vpcauthMockNewServiceVersion, req.URL.Query().Get("version"))
@@ -551,6 +616,27 @@ func TestVpcAuthRetrieveIamTokenSuccessProfileID(t *testing.T) {
 	assert.NotNil(t, iamTokenServerResponse)
 	assert.Equal(t, vpcauthTestAccessToken2, iamTokenServerResponse.AccessToken)
 }
+
+func TestVpcAuthRetrieveIamTokenSuccessProfileName(t *testing.T) {
+	GetLogger().SetLogLevel(vpcauthTestLogLevel)
+
+	server := startMockVPCServer(t, "profile-name")
+	defer server.Close()
+
+	auth := &VpcInstanceAuthenticator{
+		URL:            server.URL,
+		IAMProfileName: vpcauthMockIAMProfileName,
+	}
+	err := auth.Validate()
+	assert.Nil(t, err)
+
+	iamTokenServerResponse, err := auth.retrieveIamAccessToken(vpcauthTestInstanceIdentityToken)
+	assert.Nil(t, err)
+	assert.NotNil(t, iamTokenServerResponse)
+	assert.Equal(t, vpcauthTestAccessToken1, iamTokenServerResponse.AccessToken)
+}
+
+
 
 func TestVpcAuthRetrieveIamTokenFail1(t *testing.T) {
 	GetLogger().SetLogLevel(vpcauthTestLogLevel)

--- a/core/vpc_instance_authenticator_test.go
+++ b/core/vpc_instance_authenticator_test.go
@@ -355,10 +355,10 @@ func startMockVPCServer(t *testing.T, scenario string) *httptest.Server {
 			type trustedProfileIdentity struct {
 				// The unique identifier for this trusted profile.
 				ID *string `json:"id,omitempty"`
-	
+
 				// The CRN for this trusted profile.
 				CRN *string `json:"crn,omitempty"`
-	
+
 				// The name of this trusted profile.
 				Name *string `json:"name,omitempty"`
 			}
@@ -392,7 +392,7 @@ func startMockVPCServer(t *testing.T, scenario string) *httptest.Server {
 				assert.NotNil(t, requestBody.TrustedProfile.ID)
 				assert.Nil(t, requestBody.TrustedProfile.Name)
 				assert.Equal(t, vpcauthMockIAMProfileID, *requestBody.TrustedProfile.ID)
-	
+
 			case "profile-name":
 				assert.NotNil(t, requestBody)
 				assert.NotNil(t, requestBody.TrustedProfile)
@@ -400,7 +400,7 @@ func startMockVPCServer(t *testing.T, scenario string) *httptest.Server {
 				assert.Nil(t, requestBody.TrustedProfile.ID)
 				assert.NotNil(t, requestBody.TrustedProfile.Name)
 				assert.Equal(t, vpcauthMockIAMProfileName, *requestBody.TrustedProfile.Name)
-	
+
 			case "new-service-version":
 				assert.NotNil(t, requestBody)
 				assert.Equal(t, vpcauthMockNewServiceVersion, req.URL.Query().Get("version"))
@@ -635,8 +635,6 @@ func TestVpcAuthRetrieveIamTokenSuccessProfileName(t *testing.T) {
 	assert.NotNil(t, iamTokenServerResponse)
 	assert.Equal(t, vpcauthTestAccessToken1, iamTokenServerResponse.AccessToken)
 }
-
-
 
 func TestVpcAuthRetrieveIamTokenFail1(t *testing.T) {
 	GetLogger().SetLogLevel(vpcauthTestLogLevel)


### PR DESCRIPTION
Adds IAM Profile selector to the `VPC Instance Authenticator`.

- The name of the linked trusted IAM profile to be used as the identity of the compute resource.
- At most one of IAMProfileCRN, IAMProfileID, or IAMProfileName may be specified.
- If none is specified, the default IAM profile of the compute resource will be used.